### PR TITLE
Wallet default name and path

### DIFF
--- a/crates/core/src/wallet/mod.rs
+++ b/crates/core/src/wallet/mod.rs
@@ -59,6 +59,20 @@ pub fn get_grin_wallet_default_path(chain_type: &global::ChainTypes) -> PathBuf 
     grin_path
 }
 
+pub fn create_grin_wallet_path(chain_type: &global::ChainTypes, sub_dir: &str) -> PathBuf {
+    // Check if grin dir exists
+    let mut grin_path = match dirs::home_dir() {
+        Some(p) => p,
+        None => PathBuf::new(),
+    };
+    grin_path.push(GRIN_HOME);
+    grin_path.push(chain_type.shortname());
+    grin_path.push(GRIN_WALLET_TOP_LEVEL_DIR);
+    grin_path.push(sub_dir);
+
+    grin_path
+}
+
 pub type WalletInterfaceHttpNodeClient = WalletInterface<
     DefaultLCProvider<'static, HTTPNodeClient, keychain::ExtKeychain>,
     HTTPNodeClient,

--- a/locale/de.json
+++ b/locale/de.json
@@ -206,5 +206,6 @@
     "tx-status": "Status",
     "tx-net-difference": "Amount",
     "tx-id": "ID",
-    "tx-type": "Type"
+    "tx-type": "Type",
+    "wallet-default-name": "Default"
 }

--- a/locale/en.json
+++ b/locale/en.json
@@ -196,6 +196,7 @@
     "status-line-title-main": "Status Mainnet",
     "status-line-title-test": "Status Testnet",
     "wallet-list": "Wallets",
+    "wallet-default-name": "Default",
     "yes": "Yes",
     "no": "No",
     "cancel":"Cancel",

--- a/src/gui/element/wallet/setup/init.rs
+++ b/src/gui/element/wallet/setup/init.rs
@@ -1,9 +1,12 @@
 use {
     super::super::super::{DEFAULT_FONT_SIZE, DEFAULT_HEADER_FONT_SIZE},
-    crate::gui::{style, GrinGui, Interaction, Message},
+    crate::gui::{style, GrinGui, Interaction, Message, element::settings::wallet},
     crate::localization::localized_string,
     crate::Result,
-    grin_gui_core::{theme::ColorPalette, wallet::{create_grin_wallet_path, ChainTypes}},
+    grin_gui_core::{
+        theme::ColorPalette,
+        wallet::{create_grin_wallet_path, ChainTypes},
+    },
     iced::{
         alignment, button, Alignment, Button, Column, Command, Container, Element, Length, Row,
         Space, Text,
@@ -43,11 +46,15 @@ pub fn handle_message(
         LocalViewInteraction::WalletSetup => {
             let config = &grin_gui.config;
             let wallet_default_name = localized_string("wallet-default-name");
-            let mut wallet_display_name = wallet_default_name.clone(); 
+            let mut wallet_display_name = wallet_default_name.clone();
             let mut i = 1;
 
             // wallet display name must be unique: i.e. Default 1, Default 2, ...
-            while let Some(_) = config.wallets.iter().find(|wallet| wallet.display_name == wallet_display_name) {
+            while let Some(_) = config
+                .wallets
+                .iter()
+                .find(|wallet| wallet.display_name == wallet_display_name)
+            {
                 wallet_display_name = format!("{} {}", wallet_default_name, i);
                 i += 1;
             }
@@ -55,11 +62,14 @@ pub fn handle_message(
             // i.e. default_1, default_2, ...
             let wallet_dir: String = str::replace(&wallet_display_name.to_lowercase(), " ", "_");
 
-            state.setup_wallet_state.advanced_options_state.top_level_directory = create_grin_wallet_path(&ChainTypes::Mainnet,&wallet_dir);
-            state.setup_wallet_state.advanced_options_state.display_name_value = wallet_display_name;
-            state.mode = super::Mode::CreateWallet;
+            state
+                .setup_wallet_state
+                .advanced_options_state
+                .top_level_directory = create_grin_wallet_path(&ChainTypes::Mainnet, &wallet_dir);
+
+            state.mode = super::Mode::CreateWallet(wallet_display_name);
         }
-        LocalViewInteraction::WalletList => state.mode = super::Mode::ListWallets
+        LocalViewInteraction::WalletList => state.mode = super::Mode::ListWallets,
     }
     Ok(Command::none())
 }
@@ -68,21 +78,19 @@ pub fn data_container<'a>(
     color_palette: ColorPalette,
     state: &'a mut StateContainer,
 ) -> Container<'a, Message> {
-
     // Title row
     let title = Text::new(localized_string("setup-grin-first-time"))
         .size(DEFAULT_HEADER_FONT_SIZE)
         .horizontal_alignment(alignment::Horizontal::Center);
 
-    let title_container = Container::new(title)
-        .style(style::BrightBackgroundContainer(color_palette));
+    let title_container =
+        Container::new(title).style(style::BrightBackgroundContainer(color_palette));
 
     let title_row = Row::new()
         .push(title_container)
         .align_items(Alignment::Center)
         .padding(6)
         .spacing(20);
-        
 
     let description = Text::new(localized_string("setup-grin-wallet-description"))
         .size(DEFAULT_FONT_SIZE)
@@ -129,8 +137,7 @@ pub fn data_container<'a>(
     .into();
 
     let select_wallet_button_container =
-        Container::new(select_wallet_button.map(Message::Interaction))
-    .center_x();
+        Container::new(select_wallet_button.map(Message::Interaction)).center_x();
 
     //let mut wallet_setup_modal_column =
     /*let wallet_setup_select_column = {
@@ -160,14 +167,14 @@ pub fn data_container<'a>(
         .push(Space::new(Length::Units(0), Length::Units(unit_spacing)))
         .push(select_wallet_button_container)
         .align_items(Alignment::Center);
- 
+
     let colum = Column::new()
         .push(title_row)
         .push(Space::new(Length::Units(0), Length::Units(unit_spacing)))
         .push(description_container)
         .push(Space::new(Length::Units(0), Length::Units(unit_spacing)))
         .push(select_column)
-       .align_items(Alignment::Center);
+        .align_items(Alignment::Center);
 
     Container::new(colum)
         .center_y()

--- a/src/gui/element/wallet/setup/init.rs
+++ b/src/gui/element/wallet/setup/init.rs
@@ -46,16 +46,16 @@ pub fn handle_message(
             let mut wallet_display_name = wallet_default_name.clone(); 
             let mut i = 1;
 
-            // wallet display name must be unique
+            // wallet display name must be unique: i.e. Default 1, Default 2, ...
             while let Some(_) = config.wallets.iter().find(|wallet| wallet.display_name == wallet_display_name) {
                 wallet_display_name = format!("{} {}", wallet_default_name, i);
                 i += 1;
             }
 
-            let wallet_dir: String = wallet_display_name.chars().filter(|c| !c.is_whitespace()).collect();
-            let tld = create_grin_wallet_path(&ChainTypes::Mainnet,&wallet_dir.to_lowercase());
+            // i.e. default_1, default_2, ...
+            let wallet_dir: String = str::replace(&wallet_display_name.to_lowercase(), " ", "_");
 
-            state.setup_wallet_state.advanced_options_state.top_level_directory = tld;
+            state.setup_wallet_state.advanced_options_state.top_level_directory = create_grin_wallet_path(&ChainTypes::Mainnet,&wallet_dir);
             state.setup_wallet_state.advanced_options_state.display_name_value = wallet_display_name;
             state.mode = super::Mode::CreateWallet;
         }

--- a/src/gui/element/wallet/setup/mod.rs
+++ b/src/gui/element/wallet/setup/mod.rs
@@ -22,7 +22,7 @@ pub struct StateContainer {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Mode {
     Init,
-    CreateWallet,
+    CreateWallet(String),
     ListWallets,
     WalletCreateSuccess,
 }
@@ -54,10 +54,10 @@ pub fn data_container<'a>(
     state: &'a mut StateContainer,
     config: &Config,
 ) -> Container<'a, Message> {
-    let content = match state.mode {
+    let content = match &state.mode {
         Mode::Init => init::data_container(color_palette, &mut state.setup_init_state),
-        Mode::CreateWallet => {
-            wallet_setup::data_container(color_palette, &mut state.setup_wallet_state)
+        Mode::CreateWallet(default_display_name) => {
+            wallet_setup::data_container(color_palette, &mut state.setup_wallet_state, default_display_name)
         }
         Mode::WalletCreateSuccess => {
             wallet_success::data_container(color_palette, &mut state.setup_wallet_success_state)

--- a/src/gui/element/wallet/setup/wallet_setup.rs
+++ b/src/gui/element/wallet/setup/wallet_setup.rs
@@ -13,10 +13,10 @@ use {
     anyhow::Context,
     grin_gui_core::theme::ColorPalette,
     grin_gui_core::{
-        wallet::create_grin_wallet_path,
         config::Wallet,
         fs::PersistentData,
         node::ChainTypes::{self, Mainnet, Testnet},
+        wallet::create_grin_wallet_path,
         wallet::WalletInterface,
     },
     iced::{
@@ -112,6 +112,8 @@ pub fn handle_message<'a>(
     let state = &mut grin_gui.wallet_state.setup_state.setup_wallet_state;
     match message {
         LocalViewInteraction::Back => {
+            // reset user input values
+            grin_gui.wallet_state.setup_state.setup_wallet_state = Default::default();
             grin_gui.wallet_state.setup_state.mode = super::Mode::Init;
         }
         LocalViewInteraction::PasswordInput(password) => {
@@ -151,7 +153,6 @@ pub fn handle_message<'a>(
                 if default_path == current_tld {
                     state.advanced_options_state.top_level_directory =
                         create_grin_wallet_path(&Mainnet, directory);
-              
                 }
             }
         }
@@ -219,8 +220,13 @@ pub fn handle_message<'a>(
                 .setup_state
                 .setup_wallet_success_state
                 .recovery_phrase = mnemonic;
+
             grin_gui.wallet_state.setup_state.mode =
                 crate::gui::element::wallet::setup::Mode::WalletCreateSuccess;
+
+            // reset user input values
+            grin_gui.wallet_state.setup_state.setup_wallet_state = Default::default();
+
             let _ = grin_gui.config.save();
         }
         LocalViewInteraction::WalletCreateError(err) => {
@@ -407,8 +413,8 @@ pub fn data_container<'a>(
 
     let display_name_input = TextInput::new(
         &mut state.advanced_options_state.display_name_input_state,
-        &localized_string("wallet-default-name"), 
-        &state.advanced_options_state.display_name_value, 
+        &localized_string("wallet-default-name"),
+        &state.advanced_options_state.display_name_value,
         |s| Interaction::WalletSetupWalletViewInteraction(LocalViewInteraction::DisplayName(s)),
     )
     .size(DEFAULT_FONT_SIZE)
@@ -434,7 +440,11 @@ pub fn data_container<'a>(
     ));
     let folder_select_button: Element<Interaction> = folder_select_button.into();
 
-    let tld_string = state.advanced_options_state.top_level_directory.to_str().unwrap(); 
+    let tld_string = state
+        .advanced_options_state
+        .top_level_directory
+        .to_str()
+        .unwrap();
     let current_tld = Text::new(tld_string).size(DEFAULT_FONT_SIZE);
 
     let current_tld_container =

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -142,9 +142,6 @@ impl Application for GrinGui {
             global::set_local_chain_type(wallet.chain_type);
         } 
 
-        grin_gui.wallet_state.setup_state.setup_wallet_state.advanced_options_state.top_level_directory =
-            get_grin_wallet_default_path(&global::get_chain_type());
-
         // Check initial wallet status
         /*if !config.wallet.toml_file_path.is_some()
             || !w.config_exists(


### PR DESCRIPTION
Populate the display name and wallet directory when the user creates a new wallet with unique defaults: Default 1, Default 2, etc. The default folder path will also follow this convention:

~/.grin/main/grin_wallet/default_1 

and for testnet:

~/.grin/test/grin_wallet/default_1 