### PR TITLE
Wallet Home Screen Transaction Menu Items

### DIFF
--- a/locale/de.json
+++ b/locale/de.json
@@ -213,5 +213,8 @@
     "info-awaiting-confirmation": "Awaiting Confirmation",
     "info-awaiting-finalization": "Awaiting Finalization",
     "info-locked": "Locked",
-    "wallet-default-name": "Default"
+    "wallet-default-name": "Default",
+    "wallet-create-tx": "Send",
+    "wallet-apply-tx": "Receive",
+    "wallet-home": "Wallet - Set Name Here TBD"
 }

--- a/locale/en.json
+++ b/locale/en.json
@@ -222,5 +222,8 @@
     "info-awaiting-finalization": "Awaiting Finalization",
     "info-locked": "Locked",
     "name": "Name",
-    "folder": "Folder"
+    "folder": "Folder",
+    "wallet-create-tx": "Send",
+    "wallet-apply-tx": "Receive",
+    "wallet-home": "Wallet - Set Name Here TBD"
 }

--- a/src/gui/element/wallet/operation/action_menu.rs
+++ b/src/gui/element/wallet/operation/action_menu.rs
@@ -1,0 +1,98 @@
+use super::tx_list::{self, ExpandType};
+use crate::log_error;
+use async_std::prelude::FutureExt;
+use grin_gui_core::{
+    config::Config,
+    wallet::{TxLogEntry, TxLogEntryType},
+};
+use grin_gui_widgets::{header, Header, TableRow};
+use iced::button::StyleSheet;
+use iced_aw::Card;
+use iced_native::Widget;
+use std::path::PathBuf;
+
+use super::tx_list::{HeaderState, TxList};
+
+use {
+    super::super::super::{DEFAULT_FONT_SIZE, DEFAULT_HEADER_FONT_SIZE, DEFAULT_PADDING},
+    crate::gui::{style, GrinGui, Interaction, Message},
+    crate::localization::localized_string,
+    crate::Result,
+    anyhow::Context,
+    grin_gui_core::wallet::{StatusMessage, WalletInfo, WalletInterface},
+    grin_gui_core::{node::amount_to_hr_string, theme::ColorPalette},
+    iced::{
+        alignment, button, scrollable, text_input, Alignment, Button, Checkbox, Column, Command,
+        Container, Element, Length, Row, Scrollable, Space, Text, TextInput,
+    },
+    std::sync::{Arc, RwLock},
+    serde::{Deserialize, Serialize}
+};
+
+pub struct StateContainer {
+    pub create_tx_button_state: button::State,
+    pub action_menu_action: Action,
+}
+
+impl Default for StateContainer {
+    fn default() -> Self {
+        Self {
+            action_menu_action: Action::None,
+            create_tx_button_state: Default::default(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum Action {
+    None,
+    CreateTx,
+    ApplyTx,
+}
+
+#[derive(Debug, Clone)]
+pub enum LocalViewInteraction {
+    SelectAction(Action),
+}
+
+pub fn handle_message<'a>(
+    grin_gui: &mut GrinGui,
+    message: LocalViewInteraction,
+) -> Result<Command<Message>> {
+    let state = &mut grin_gui.wallet_state.operation_state.home_state.action_menu_state;
+    match message {
+        LocalViewInteraction::SelectAction(action) => {
+            log::debug!("Interaction::WalletOperationHomeActionMenuViewInteraction({:?})", action);
+            grin_gui.wallet_state.operation_state.home_state.action_menu_state.action_menu_action = action;
+        }
+    }
+    Ok(Command::none())
+}
+
+pub fn data_container<'a>(
+    color_palette: ColorPalette,
+    config: &'a Config,
+    state: &'a mut StateContainer,
+) -> Container<'a, Message> {
+    // Buttons to perform wallet operations
+    let menu_column = Column::new();
+    let menu_container = Container::new(menu_column).width(Length::FillPortion(2));
+
+    let mut create_tx_button: Button<Interaction> = Button::new(
+        &mut state.create_tx_button_state,
+        Text::new(localized_string("wallet")).size(DEFAULT_FONT_SIZE),
+    )
+    .on_press(Interaction::WalletOperationHomeActionMenuViewInteraction(
+        LocalViewInteraction::SelectAction(Action::CreateTx),
+    ));
+
+    // Overall operations menu screen layout column
+    let column = Column::new()
+        .push(menu_container)
+        .align_items(Alignment::Center);
+
+    Container::new(column)
+        .center_y()
+        .center_x()
+        .width(Length::Fill)
+}

--- a/src/gui/element/wallet/operation/apply_tx.rs
+++ b/src/gui/element/wallet/operation/apply_tx.rs
@@ -1,0 +1,117 @@
+use super::tx_list::{self, ExpandType};
+use crate::log_error;
+use async_std::prelude::FutureExt;
+use grin_gui_core::{
+    config::Config,
+    wallet::{TxLogEntry, TxLogEntryType},
+};
+use grin_gui_widgets::{header, Header, TableRow};
+use iced::button::StyleSheet;
+use iced_aw::Card;
+use iced_native::Widget;
+use std::path::PathBuf;
+
+use super::tx_list::{HeaderState, TxList};
+
+use {
+    super::super::super::{DEFAULT_FONT_SIZE, DEFAULT_HEADER_FONT_SIZE, DEFAULT_PADDING},
+    crate::gui::{style, GrinGui, Interaction, Message},
+    crate::localization::localized_string,
+    crate::Result,
+    anyhow::Context,
+    grin_gui_core::wallet::{StatusMessage, WalletInfo, WalletInterface},
+    grin_gui_core::{node::amount_to_hr_string, theme::ColorPalette},
+    iced::{
+        alignment, button, scrollable, text_input, Alignment, Button, Checkbox, Column, Command,
+        Container, Element, Length, Row, Scrollable, Space, Text, TextInput,
+    },
+    serde::{Deserialize, Serialize},
+    std::sync::{Arc, RwLock},
+};
+
+pub struct StateContainer {
+    pub back_button_state: button::State,
+}
+
+impl Default for StateContainer {
+    fn default() -> Self {
+        Self {
+            back_button_state: Default::default(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum Action {
+}
+
+#[derive(Debug, Clone)]
+pub enum LocalViewInteraction {
+    Back,
+}
+
+pub fn handle_message<'a>(
+    grin_gui: &mut GrinGui,
+    message: LocalViewInteraction,
+) -> Result<Command<Message>> {
+    /*let state = &mut grin_gui
+        .wallet_state
+        .operation_state
+        .home_state
+        .action_menu_state;*/
+    match message {
+        LocalViewInteraction::Back => {
+            log::debug!(
+                "Interaction::WalletOperationApplyTxViewInteraction(Back)"
+            );
+            grin_gui.wallet_state.operation_state.mode = crate::gui::element::wallet::operation::Mode::Home;
+        }
+    }
+    Ok(Command::none())
+}
+
+pub fn data_container<'a>(
+    color_palette: ColorPalette,
+    config: &'a Config,
+    state: &'a mut StateContainer,
+) -> Container<'a, Message> {
+    // Title row
+    let title = Text::new(localized_string("apply-tx"))
+        .size(DEFAULT_HEADER_FONT_SIZE)
+        .horizontal_alignment(alignment::Horizontal::Center);
+
+    let title_container =
+        Container::new(title).style(style::BrightBackgroundContainer(color_palette));
+
+    let back_button_label_container =
+        Container::new(Text::new(localized_string("back")).size(DEFAULT_FONT_SIZE))
+            .height(Length::Units(20))
+            .align_y(alignment::Vertical::Bottom)
+            .align_x(alignment::Horizontal::Center);
+
+    let back_button: Element<Interaction> =
+        Button::new(&mut state.back_button_state, back_button_label_container)
+            .style(style::NormalTextButton(color_palette))
+            .on_press(Interaction::WalletOperationApplyTxViewInteraction(
+                LocalViewInteraction::Back,
+            ))
+            .into();
+
+    let title_row = Row::new()
+        .push(title_container)
+        .push(back_button.map(Message::Interaction))
+        //.push(Space::new(Length::Fill, Length::Units(0)))
+        .align_items(Alignment::Center)
+        .padding(6)
+        .spacing(20);
+
+    let column = Column::new()
+        .push(title_row)
+        .padding(10) 
+        .align_items(Alignment::Center);
+
+    Container::new(column)
+        .center_y()
+        .center_x()
+        .width(Length::Fill)
+}

--- a/src/gui/element/wallet/operation/create_tx.rs
+++ b/src/gui/element/wallet/operation/create_tx.rs
@@ -1,0 +1,119 @@
+use super::tx_list::{self, ExpandType};
+use crate::log_error;
+use async_std::prelude::FutureExt;
+use grin_gui_core::{
+    config::Config,
+    wallet::{TxLogEntry, TxLogEntryType},
+};
+use grin_gui_widgets::{header, Header, TableRow};
+use iced::button::StyleSheet;
+use iced_aw::Card;
+use iced_native::Widget;
+use std::path::PathBuf;
+
+use super::tx_list::{HeaderState, TxList};
+
+use {
+    super::super::super::{DEFAULT_FONT_SIZE, DEFAULT_HEADER_FONT_SIZE, DEFAULT_PADDING},
+    crate::gui::{style, GrinGui, Interaction, Message},
+    crate::localization::localized_string,
+    crate::Result,
+    anyhow::Context,
+    grin_gui_core::wallet::{StatusMessage, WalletInfo, WalletInterface},
+    grin_gui_core::{node::amount_to_hr_string, theme::ColorPalette},
+    iced::{
+        alignment, button, scrollable, text_input, Alignment, Button, Checkbox, Column, Command,
+        Container, Element, Length, Row, Scrollable, Space, Text, TextInput,
+    },
+    serde::{Deserialize, Serialize},
+    std::sync::{Arc, RwLock},
+};
+
+pub struct StateContainer {
+    pub back_button_state: button::State,
+}
+
+impl Default for StateContainer {
+    fn default() -> Self {
+        Self {
+            back_button_state: Default::default(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum Action {
+}
+
+#[derive(Debug, Clone)]
+pub enum LocalViewInteraction {
+    Back,
+}
+
+pub fn handle_message<'a>(
+    grin_gui: &mut GrinGui,
+    message: LocalViewInteraction,
+) -> Result<Command<Message>> {
+    /*let state = &mut grin_gui
+        .wallet_state
+        .operation_state
+        .home_state
+        .action_menu_state;*/
+
+    match message {
+        LocalViewInteraction::Back => {
+            log::debug!(
+                "Interaction::WalletOperationCreateTxViewInteraction(Back)"
+            );
+            grin_gui.wallet_state.operation_state.mode = crate::gui::element::wallet::operation::Mode::Home;
+        }
+    }
+
+    Ok(Command::none())
+}
+
+pub fn data_container<'a>(
+    color_palette: ColorPalette,
+    config: &'a Config,
+    state: &'a mut StateContainer,
+) -> Container<'a, Message> {
+    // Title row
+    let title = Text::new(localized_string("create-tx"))
+        .size(DEFAULT_HEADER_FONT_SIZE)
+        .horizontal_alignment(alignment::Horizontal::Center);
+
+    let title_container =
+        Container::new(title).style(style::BrightBackgroundContainer(color_palette));
+
+    let back_button_label_container =
+        Container::new(Text::new(localized_string("back")).size(DEFAULT_FONT_SIZE))
+            .height(Length::Units(20))
+            .align_y(alignment::Vertical::Bottom)
+            .align_x(alignment::Horizontal::Center);
+
+    let back_button: Element<Interaction> =
+        Button::new(&mut state.back_button_state, back_button_label_container)
+            .style(style::NormalTextButton(color_palette))
+            .on_press(Interaction::WalletOperationCreateTxViewInteraction(
+                LocalViewInteraction::Back,
+            ))
+            .into();
+
+    let title_row = Row::new()
+        .push(title_container)
+        .push(back_button.map(Message::Interaction))
+        //.push(Space::new(Length::Fill, Length::Units(0)))
+        .align_items(Alignment::Center)
+        .padding(6)
+        .spacing(20);
+
+    let column = Column::new()
+        .push(title_row)
+        .padding(10) 
+        .align_items(Alignment::Center);
+
+    Container::new(column)
+        .center_y()
+        .center_x()
+        .width(Length::Fill)
+}

--- a/src/gui/element/wallet/operation/home.rs
+++ b/src/gui/element/wallet/operation/home.rs
@@ -214,8 +214,8 @@ pub fn data_container<'a>(
 
     let title_row = Row::new()
         .push(title_container)
-        .push(Space::new(Length::Units(100), Length::Units(0)))
         .push(back_button.map(Message::Interaction))
+        //.push(Space::new(Length::Fill, Length::Units(0)))
         .align_items(Alignment::Center)
         .padding(6)
         .spacing(20);
@@ -350,12 +350,12 @@ pub fn data_container<'a>(
     )
     .style(style::NormalModalCardContainer(color_palette));
 
-    let wallet_info_card_container = Container::new(wallet_info_card).width(Length::FillPortion(3));
+    let wallet_info_card_container = Container::new(wallet_info_card).width(Length::FillPortion(2));
 
     // Home 'row', operation buttons beside info
     let first_row_container = Row::new()
-        .push(operations_menu)
         .push(wallet_info_card_container)
+        .push(operations_menu)
         .padding(10);
 
     // Status container bar at bottom of screen
@@ -488,12 +488,11 @@ pub fn data_container<'a>(
     // Overall Home screen layout column
     let column = Column::new()
         .push(title_row)
-        .push(Space::new(Length::Units(0), Length::Fill))
         .push(first_row_container)
-        .push(Space::new(Length::Units(0), Length::Fill))
         .push(tx_list_content)
-        .push(Space::new(Length::Units(0), Length::Units(20)))
+        .push(Space::new(Length::Units(0), Length::Fill))
         .push(status_row)
+        .padding(10) 
         .align_items(Alignment::Center);
 
     Container::new(column)

--- a/src/gui/element/wallet/operation/home.rs
+++ b/src/gui/element/wallet/operation/home.rs
@@ -12,6 +12,7 @@ use iced_native::Widget;
 use std::path::PathBuf;
 
 use super::tx_list::{HeaderState, TxList};
+use super::action_menu;
 
 use {
     super::super::super::{DEFAULT_FONT_SIZE, DEFAULT_HEADER_FONT_SIZE, DEFAULT_PADDING},
@@ -29,6 +30,7 @@ use {
 };
 
 pub struct StateContainer {
+    pub action_menu_state: action_menu::StateContainer,
     pub back_button_state: button::State,
     pub expanded_type: ExpandType,
 
@@ -43,6 +45,7 @@ pub struct StateContainer {
 impl Default for StateContainer {
     fn default() -> Self {
         Self {
+            action_menu_state: Default::default(),
             back_button_state: Default::default(),
             expanded_type: ExpandType::None,
             wallet_info: Default::default(),
@@ -218,9 +221,7 @@ pub fn data_container<'a>(
         .spacing(20);
 
     // Buttons to perform operations go here, but empty container for now
-    let operations_menu_column = Column::new();
-    let operations_menu_container =
-        Container::new(operations_menu_column).width(Length::FillPortion(2));
+    let operations_menu = action_menu::data_container(color_palette, config, &mut state.action_menu_state);
 
     // Basic Info "Box"
     let waiting_string = "---------";
@@ -353,7 +354,7 @@ pub fn data_container<'a>(
 
     // Home 'row', operation buttons beside info
     let first_row_container = Row::new()
-        .push(operations_menu_container)
+        .push(operations_menu)
         .push(wallet_info_card_container)
         .padding(10);
 

--- a/src/gui/element/wallet/operation/mod.rs
+++ b/src/gui/element/wallet/operation/mod.rs
@@ -2,6 +2,8 @@ pub mod open;
 pub mod action_menu;
 pub mod home;
 pub mod tx_list;
+pub mod create_tx;
+pub mod apply_tx;
 
 use {
     crate::gui::{style, GrinGui, Message},
@@ -15,6 +17,8 @@ pub struct StateContainer {
     pub mode: Mode,
     pub open_state: open::StateContainer,
     pub home_state: home::StateContainer,
+    pub create_tx_state: create_tx::StateContainer,
+    pub apply_tx_state: apply_tx::StateContainer,
     // When changed to true, this should stay false until a wallet is opened with a password
     has_wallet_open_check_failed_one_time: bool,
 }
@@ -23,6 +27,8 @@ pub struct StateContainer {
 pub enum Mode {
     Open,
     Home,
+    CreateTx,
+    ApplyTx
 }
 
 impl Default for StateContainer {
@@ -31,6 +37,8 @@ impl Default for StateContainer {
             mode: Mode::Home,
             open_state: Default::default(),
             home_state: Default::default(),
+            create_tx_state: Default::default(),
+            apply_tx_state: Default::default(),
             has_wallet_open_check_failed_one_time: false,
         }
     }
@@ -72,6 +80,12 @@ pub fn data_container<'a>(
         Mode::Open => open::data_container(color_palette, &mut state.open_state, config),
         Mode::Home => {
             home::data_container(color_palette, config, &mut state.home_state)
+        }
+        Mode::CreateTx => {
+            create_tx::data_container(color_palette, config, &mut state.create_tx_state)
+        }
+        Mode::ApplyTx => {
+            apply_tx::data_container(color_palette, config, &mut state.apply_tx_state)
         }
     };
 

--- a/src/gui/element/wallet/operation/mod.rs
+++ b/src/gui/element/wallet/operation/mod.rs
@@ -1,4 +1,5 @@
 pub mod open;
+pub mod action_menu;
 pub mod home;
 pub mod tx_list;
 

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -430,6 +430,7 @@ pub enum Interaction {
     WalletOperationOpenViewInteraction(element::wallet::operation::open::LocalViewInteraction),
     WalletOperationHomeViewInteraction(element::wallet::operation::home::LocalViewInteraction),
     WalletOperationTxListInteraction(element::wallet::operation::tx_list::LocalViewInteraction),
+    WalletOperationHomeActionMenuViewInteraction(element::wallet::operation::action_menu::LocalViewInteraction),
     ViewInteraction(String, String),
     ModeSelected(Mode),
     ModeSelectedSettings(element::settings::Mode),

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -431,6 +431,8 @@ pub enum Interaction {
     WalletOperationHomeViewInteraction(element::wallet::operation::home::LocalViewInteraction),
     WalletOperationTxListInteraction(element::wallet::operation::tx_list::LocalViewInteraction),
     WalletOperationHomeActionMenuViewInteraction(element::wallet::operation::action_menu::LocalViewInteraction),
+    WalletOperationCreateTxViewInteraction(element::wallet::operation::create_tx::LocalViewInteraction),
+    WalletOperationApplyTxViewInteraction(element::wallet::operation::apply_tx::LocalViewInteraction),
     ViewInteraction(String, String),
     ModeSelected(Mode),
     ModeSelectedSettings(element::settings::Mode),

--- a/src/gui/update.rs
+++ b/src/gui/update.rs
@@ -168,7 +168,19 @@ pub fn handle_message(grin_gui: &mut GrinGui, message: Message) -> Result<Comman
         Message::Interaction(Interaction::WalletOperationTxListInteraction(l)) => {
             return element::wallet::operation::tx_list::handle_message(grin_gui, l);
         }
-         Message::Interaction(Interaction::ModeSelected(mode)) => {
+        // Wallet -> Operation -> CreateTx
+        Message::Interaction(Interaction::WalletOperationCreateTxViewInteraction(l)) => {
+            return element::wallet::operation::create_tx::handle_message(grin_gui, l);
+        }
+        // Wallet -> Operation -> Home -> Action
+        Message::Interaction(Interaction::WalletOperationApplyTxViewInteraction(l)) => {
+            return element::wallet::operation::apply_tx::handle_message(grin_gui, l);
+        }
+        // Wallet -> Operation -> Home -> Action
+        Message::Interaction(Interaction::WalletOperationHomeActionMenuViewInteraction(l)) => {
+            return element::wallet::operation::action_menu::handle_message(grin_gui, l);
+        }
+          Message::Interaction(Interaction::ModeSelected(mode)) => {
             log::debug!("Interaction::ModeSelected({:?})", mode);
             // Set Mode
             grin_gui.mode = mode;


### PR DESCRIPTION
* Add infrastructure for transaction creation / reception screens
* Add wallet action menu to wallet homescreen
* Slight re-arrangement of wallet home screen layout