### PR TITLE
Store and recall encrypted slate during send operations

### DIFF
--- a/crates/core/src/config/mod.rs
+++ b/crates/core/src/config/mod.rs
@@ -1,6 +1,7 @@
 use crate::backup::CompressionFormat;
 use crate::error::FilesystemError;
 use serde::{Deserialize, Serialize};
+use std::f32::consts::E;
 use std::fmt::{self, Display, Formatter};
 use std::path::PathBuf;
 
@@ -70,9 +71,23 @@ pub struct Config {
 }
 
 impl Config {
-    pub fn add_wallet(&mut self, wallet: Wallet) -> usize{
+    pub fn add_wallet(&mut self, wallet: Wallet) -> usize {
         self.wallets.push(wallet);
         self.wallets.len() - 1
+    }
+
+    pub fn get_wallet_slatepack_dir(&self) -> Option<String> {
+        if let Some(i) = self.current_wallet_index.as_ref() {
+            if let Some(ref tld) = self.wallets[*i].tld {
+                let slate_dir = format!("{}/{}", tld.as_os_str().to_str().unwrap(), "slatepack");
+                let _ = std::fs::create_dir_all(slate_dir.clone());
+                Some(slate_dir)
+            } else {
+                None
+            }
+        } else {
+            None
+        }
     }
 }
 
@@ -167,10 +182,7 @@ impl std::fmt::Display for Language {
 
 impl Language {
     // Alphabetically sorted based on their local name (@see `impl Display`).
-    pub const ALL: [Language; 2] = [
-        Language::German,
-        Language::English,
-    ];
+    pub const ALL: [Language; 2] = [Language::German, Language::English];
 
     pub const fn language_code(self) -> &'static str {
         match self {
@@ -186,10 +198,11 @@ impl Default for Language {
     }
 }
 
-
-#[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, Hash, PartialOrd, Ord)]
+#[derive(
+    Default, Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, Hash, PartialOrd, Ord,
+)]
 pub enum Currency {
-    #[default] 
+    #[default]
     GRIN,
     BTC,
     USD,
@@ -211,35 +224,31 @@ impl std::fmt::Display for Currency {
 
 impl Currency {
     // Alphabetically sorted based on their local name (@see `impl Display`).
-    pub const ALL: [Currency; 3] = [
-        Currency::BTC,
-        Currency::GRIN,
-        Currency::USD,
-    ];
+    pub const ALL: [Currency; 3] = [Currency::BTC, Currency::GRIN, Currency::USD];
 
     pub fn shortname(&self) -> String {
-		match *self {
-			Currency::BTC => "btc".to_owned(),
-			Currency::GRIN => "grin".to_owned(),
-			Currency::USD => "usd".to_owned(),
-		}
-	}
+        match *self {
+            Currency::BTC => "btc".to_owned(),
+            Currency::GRIN => "grin".to_owned(),
+            Currency::USD => "usd".to_owned(),
+        }
+    }
 
     pub fn symbol(&self) -> String {
-		match *self {
-			Currency::BTC => "₿".to_owned(),
-			Currency::GRIN => "".to_owned(),
-			Currency::USD => "$".to_owned(),
-		}
-	}
+        match *self {
+            Currency::BTC => "₿".to_owned(),
+            Currency::GRIN => "".to_owned(),
+            Currency::USD => "$".to_owned(),
+        }
+    }
 
     pub fn precision(&self) -> usize {
-		match *self {
-			Currency::BTC => 8,
-			Currency::GRIN => 9,
-			Currency::USD => 4,
-		}
-	}
+        match *self {
+            Currency::BTC => 8,
+            Currency::GRIN => 9,
+            Currency::USD => 4,
+        }
+    }
 }
 
 /// Returns a Config.

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -14,6 +14,8 @@ pub enum GrinWalletInterfaceError {
     ForeignAPINotInstantiated,
     #[error("Invalid Slatepack Address")]
     InvalidSlatepackAddress,
+    #[error("Can't load slatepack file at {file}")]
+    InvalidSlatepackFile{file: String},
 }
 
 #[derive(thiserror::Error, Debug)]

--- a/locale/de.json
+++ b/locale/de.json
@@ -245,5 +245,6 @@
     "apply-tx-confirm": "Confirm Transaction Details",
     "tx-sender-name": "Sender",
     "apply-tx-amount": "Incoming amount",
-    "tx-state": "Transaction Stage (this will be presented better)"
+    "tx-state": "Transaction Stage (this will be presented better)",
+    "tx-reload-slate": "Show Slatepack"
 }

--- a/locale/en.json
+++ b/locale/en.json
@@ -254,5 +254,6 @@
     "apply-tx-confirm": "Confirm Transaction Details",
     "tx-sender-name": "Sender",
     "apply-tx-amount": "Incoming amount",
-    "tx-state": "Transaction Stage (this will be presented better)"
+    "tx-state": "Transaction Stage (this will be presented better)",
+    "tx-reload-slate": "Show Slatepack"
 }

--- a/src/gui/element/wallet/operation/tx_list.rs
+++ b/src/gui/element/wallet/operation/tx_list.rs
@@ -1590,6 +1590,7 @@ pub fn data_row_container<'a, 'b>(
                     .style(grin_gui_core::theme::ContainerStyle::Segmented)
                     .padding(1);
 
+
                 action_button_row = Row::new()
                     .push(Space::new(
                         Length::Units(DEFAULT_PADDING * 3),
@@ -1599,6 +1600,29 @@ pub fn data_row_container<'a, 'b>(
                     .push(Space::with_width(Length::Units(DEFAULT_PADDING)));
 
                 if !confirmed {
+                    // Re-fetch the slate representing the last saved state
+                    let tx_reload_slate_container = Container::new(
+                        Text::new(localized_string("tx-reload-slate")).size(DEFAULT_FONT_SIZE),
+                    )
+                    .width(button_width)
+                    .align_y(alignment::Vertical::Center)
+                    .align_x(alignment::Horizontal::Center);
+
+                    let tx_reload_slate_button: Element<Interaction> = Button::new(tx_reload_slate_container)
+                        .width(Length::Units(BUTTON_WIDTH))
+                        .style(grin_gui_core::theme::ButtonStyle::Primary)
+                        .on_press(Interaction::WalletOperationHomeViewInteraction(
+                            super::home::LocalViewInteraction::ReloadTxSlate(tx_cloned_for_row.tx.tx_slate_id.unwrap().to_string()),
+                        ))
+                        .into();
+
+                    let tx_reload_slate_wrap =
+                        Container::new(tx_reload_slate_button.map(Message::Interaction)).padding(1);
+                    let tx_reload_slate_wrap = Container::new(tx_reload_slate_wrap)
+                        .style(grin_gui_core::theme::ContainerStyle::Segmented)
+                        .padding(1);
+
+                    // Present cancel button
                     let tx_button_cancel_container = Container::new(
                         Text::new(localized_string("cancel-tx")).size(DEFAULT_FONT_SIZE),
                     )
@@ -1613,6 +1637,7 @@ pub fn data_row_container<'a, 'b>(
                             .on_press(Interaction::WalletOperationHomeViewInteraction(
                                 super::home::LocalViewInteraction::CancelTx(
                                     tx_log_entry_wrap.tx.id,
+                                    tx_log_entry_wrap.tx.tx_slate_id.unwrap().to_string()
                                 ),
                             ))
                             .into();
@@ -1623,6 +1648,7 @@ pub fn data_row_container<'a, 'b>(
                         .style(grin_gui_core::theme::ContainerStyle::Segmented)
                         .padding(1);
 
+                    action_button_row = action_button_row.push(tx_reload_slate_wrap);
                     action_button_row = action_button_row.push(tx_cancel_wrap)
                 }
 


### PR DESCRIPTION
* Add a button to transaction list details, 'Show Slate' which re-displays the latest version of the encrypted slate for the transaction
* latest version of encrypted slate for each tx is stored at [wallet_dir]\slatepack\[tx_uuid].slatepack, this file should always contain the latest version of the encrypted slate
* Transaction file is deleted once the slate is posted to the chain (likely need to stop displaying the slate button once it's been posted)