### PR TITLE
Transaction list clean up

### DIFF
--- a/locale/de.json
+++ b/locale/de.json
@@ -246,5 +246,7 @@
     "tx-sender-name": "Sender",
     "apply-tx-amount": "Incoming amount",
     "tx-state": "Transaction Stage (this will be presented better)",
-    "tx-reload-slate": "Show Slatepack"
+    "tx-reload-slate": "Show Slatepack",
+    "txs-list-loading": "Transactions not loaded",
+    "no-txs-list": "No transactions matching the current filter have been found."
 }

--- a/locale/en.json
+++ b/locale/en.json
@@ -255,5 +255,7 @@
     "tx-sender-name": "Sender",
     "apply-tx-amount": "Incoming amount",
     "tx-state": "Transaction Stage (this will be presented better)",
-    "tx-reload-slate": "Show Slatepack"
+    "tx-reload-slate": "Show Slatepack",
+    "no-txs-list": "No transactions matching the current filter have been found.",
+    "txs-list-loading": "Transactions not loaded"
 }


### PR DESCRIPTION
* Clean up transaction list slightly
* Make filter buttons more stateful
* transaction list updates every time the wallet's info changes (likely need to make this more precise)
* Empty state for transaction list
* Separate events for refresh and select current filter set for TX