### PR TITLE
Wallet open error

### DIFF
--- a/locale/en.json
+++ b/locale/en.json
@@ -67,6 +67,7 @@
     "open": "Open",
     "open-wallet": "Open Wallet",
     "open-wallet-password": "Please enter your wallet password",
+    "open-wallet-error": "Is password correct?",
     "or-caps": "OR",
     "ok-caps": "OK",
     "parsing-addons": "Currently parsing {flavor} AddOns",

--- a/src/gui/element/modal.rs
+++ b/src/gui/element/modal.rs
@@ -88,7 +88,7 @@ pub fn exit_card() -> Card<'static, Message> {
             .push(button_row),
     )
     .max_width(500)
-    .on_close(Message::Interaction(Interaction::CloseErrorModal))
+    .on_close(Message::Interaction(Interaction::ExitCancel))
     .style(grin_gui_core::theme::CardStyle::Normal)
 }
 

--- a/src/gui/element/wallet/operation/open.rs
+++ b/src/gui/element/wallet/operation/open.rs
@@ -28,30 +28,26 @@ static UNIT_SPACE: u16 = 15;
 
 pub struct StateContainer {
     pub password_state: PasswordState,
-    // pub submit_button_state: button::State,
-    // cancel_button_state: button::State,
+    pub wallet_message: String,
 }
 
 impl Default for StateContainer {
     fn default() -> Self {
         Self {
             password_state: Default::default(),
-            // submit_button_state: Default::default(),
-            // cancel_button_state: Default::default(),
+            wallet_message: localized_string("open-wallet-password"),
         }
     }
 }
 
 #[derive(Debug, Clone)]
 pub struct PasswordState {
-    // pub input_state: text_input::State,
     pub input_value: String,
 }
 
 impl Default for PasswordState {
     fn default() -> Self {
         PasswordState {
-            // input_state: Default::default(),
             input_value: Default::default(),
         }
     }
@@ -88,6 +84,7 @@ pub fn handle_message<'a>(
         }
         LocalViewInteraction::PasswordInput(password) => {
             state.password_state.input_value = password;
+            state.wallet_message = localized_string("open-wallet-password");
         }
         LocalViewInteraction::PasswordInputEnterPressed => {
             //state.password_state.input_state.unfocus();
@@ -159,10 +156,10 @@ pub fn handle_message<'a>(
         }
 
         LocalViewInteraction::WalletOpenError(err) => {
-            grin_gui.error = err.write().unwrap().take();
-            if let Some(e) = grin_gui.error.as_ref() {
-                log_error(e);
-            }
+            //grin_gui.error = err.write().unwrap().take();
+            // display wallet message to user 
+            state.wallet_message = localized_string("open-wallet-error");
+            err.write().unwrap().take().and_then(|e| Some(log_error(&e)));
         }
     }
     Ok(Command::none())
@@ -217,7 +214,7 @@ pub fn data_container<'a>(
         Column::new().push(password_input_col)
     };
 
-    let description = Text::new(localized_string("open-wallet-password"))
+    let description = Text::new(state.wallet_message.clone())
         .size(DEFAULT_FONT_SIZE)
         .horizontal_alignment(alignment::Horizontal::Center);
 

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -74,7 +74,7 @@ pub struct GrinGui {
 
 impl GrinGui {
     pub fn show_exit (&mut self, show: bool) {
-        self.show_exit_modal = true;
+        self.show_exit_modal = show;
         self.show_error_modal = false;
     }
 

--- a/src/gui/update.rs
+++ b/src/gui/update.rs
@@ -123,8 +123,8 @@ pub fn handle_message(grin_gui: &mut GrinGui, message: Message) -> Result<Comman
             }
         },
         // Error modal state
-        Message::Interaction(Interaction::OpenErrorModal) =>  grin_gui.show_error_modal = true,
-        Message::Interaction(Interaction::CloseErrorModal) => grin_gui.show_error_modal = false,
+        Message::Interaction(Interaction::OpenErrorModal) =>  grin_gui.show_modal = true,
+        Message::Interaction(Interaction::CloseErrorModal) => grin_gui.show_modal = false,
         // Clipboard messages
         Message::Interaction(Interaction::WriteToClipboard(contents)) => {
             return Ok(clipboard::write::<Message>(contents));


### PR DESCRIPTION
This is a slight improvement to wallet open failure. The user should see an incorrect password message above the password input now instead of seeing an error on the menu bar. This is address a minor bug when canceling out of the exit app modal.