### PR TITLE
App rework, pt 1 - updates to new user workflow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "ab_glyph"
-version = "0.2.23"
+version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80179d7dd5d7e8c285d67c4a1e652972a92de7475beddfb92028c76463b13225"
+checksum = "6f90148830dac590fac7ccfe78ec4a8ea404c60f75a24e16407a71f0f40de775"
 dependencies = [
  "ab_glyph_rasterizer",
  "owned_ttf_parser",
@@ -99,7 +99,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if 1.0.0",
- "getrandom 0.2.12",
+ "getrandom 0.2.14",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -116,9 +116,9 @@ dependencies = [
 
 [[package]]
 name = "allocator-api2"
-version = "0.2.16"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
+checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
 name = "android-activity"
@@ -173,9 +173,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.81"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
+checksum = "f538837af36e6f6a9be0faa67f9a314f8119e4e4b5867c6ab40ed60360142519"
 
 [[package]]
 name = "approx"
@@ -269,27 +269,26 @@ dependencies = [
 
 [[package]]
 name = "async-channel"
-version = "2.2.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28243a43d821d11341ab73c80bed182dc015c514b951616cf79bd4af39af0c3"
+checksum = "136d4d23bcc79e27423727b36823d86233aad06dfea531837b038394d11e9928"
 dependencies = [
  "concurrent-queue",
- "event-listener 5.2.0",
- "event-listener-strategy 0.5.1",
+ "event-listener 5.3.0",
+ "event-listener-strategy 0.5.2",
  "futures-core",
  "pin-project-lite 0.2.14",
 ]
 
 [[package]]
 name = "async-executor"
-version = "1.9.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10b3e585719c2358d2660232671ca8ca4ddb4be4ce8a1842d6c2dc8685303316"
+checksum = "b10202063978b3351199d68f8b22c4e47e4b1b822f8d43fd862d5ea8c006b29a"
 dependencies = [
- "async-lock 3.3.0",
  "async-task",
  "concurrent-queue",
- "fastrand 2.0.2",
+ "fastrand 2.1.0",
  "futures-lite 2.3.0",
  "slab",
 ]
@@ -300,7 +299,7 @@ version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
 dependencies = [
- "async-channel 2.2.0",
+ "async-channel 2.2.1",
  "async-executor",
  "async-io 2.3.2",
  "async-lock 3.3.0",
@@ -341,8 +340,8 @@ dependencies = [
  "futures-io",
  "futures-lite 2.3.0",
  "parking",
- "polling 3.6.0",
- "rustix 0.38.32",
+ "polling 3.7.0",
+ "rustix 0.38.34",
  "slab",
  "tracing",
  "windows-sys 0.52.0",
@@ -381,26 +380,26 @@ dependencies = [
  "cfg-if 1.0.0",
  "event-listener 3.1.0",
  "futures-lite 1.13.0",
- "rustix 0.38.32",
+ "rustix 0.38.34",
  "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "async-signal"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e47d90f65a225c4527103a8d747001fc56e375203592b25ad103e1ca13124c5"
+checksum = "afe66191c335039c7bb78f99dc7520b0cbb166b3a1cb33a03f53d8a1c6f2afda"
 dependencies = [
  "async-io 2.3.2",
- "async-lock 2.8.0",
+ "async-lock 3.3.0",
  "atomic-waker",
  "cfg-if 1.0.0",
  "futures-core",
  "futures-io",
- "rustix 0.38.32",
+ "rustix 0.38.34",
  "signal-hook-registry",
  "slab",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -432,9 +431,9 @@ dependencies = [
 
 [[package]]
 name = "async-task"
-version = "4.7.0"
+version = "4.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbb36e985947064623dbd357f727af08ffd077f93d696782f3c56365fa2e2799"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "atk-sys"
@@ -667,18 +666,16 @@ dependencies = [
 
 [[package]]
 name = "blocking"
-version = "1.5.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a37913e8dc4ddcc604f0c6d3bf2887c995153af3611de9e23c352b44c1b9118"
+checksum = "495f7104e962b7356f0aeb34247aca1fe7d2e783b346582db7f2904cb5717e88"
 dependencies = [
- "async-channel 2.2.0",
+ "async-channel 2.2.1",
  "async-lock 3.3.0",
  "async-task",
- "fastrand 2.0.2",
  "futures-io",
  "futures-lite 2.3.0",
  "piper",
- "tracing",
 ]
 
 [[package]]
@@ -699,9 +696,15 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.15.4"
+version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ff69b9dd49fd426c69a0db9fc04dd934cdb6645ff000864d98f7e2af8830eaa"
+checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+
+[[package]]
+name = "by_address"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
 
 [[package]]
 name = "byte-tools"
@@ -724,9 +727,9 @@ version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4da9a32f3fed317401fa3c862968128267c3106685286e15d5aaa3d7389c2f60"
 dependencies = [
- "proc-macro2 1.0.79",
- "quote 1.0.35",
- "syn 2.0.57",
+ "proc-macro2 1.0.81",
+ "quote 1.0.36",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -796,8 +799,8 @@ checksum = "fba7adb4dd5aa98e5553510223000e7148f621165ec5f9acd7113f6ca4995298"
 dependencies = [
  "bitflags 2.5.0",
  "log",
- "polling 3.6.0",
- "rustix 0.38.32",
+ "polling 3.7.0",
+ "rustix 0.38.34",
  "slab",
  "thiserror",
 ]
@@ -809,7 +812,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f0ea9b9476c7fad82841a8dbb380e2eae480c21910feba80725b46931ed8f02"
 dependencies = [
  "calloop",
- "rustix 0.38.32",
+ "rustix 0.38.34",
  "wayland-backend",
  "wayland-client",
 ]
@@ -834,12 +837,13 @@ checksum = "a2698f953def977c68f935bb0dfa959375ad4638570e969e2f1e9f433cbf1af6"
 
 [[package]]
 name = "cc"
-version = "1.0.90"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
+checksum = "d32a725bc159af97c3e629873bb9f88fb8cf8a4867175f76dc987815ea07c83b"
 dependencies = [
  "jobserver",
  "libc",
+ "once_cell",
 ]
 
 [[package]]
@@ -908,9 +912,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.37"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0d04d43504c61aa6c7531f1871dd0d418d91130162063b789da00fd7057a5e"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -918,7 +922,7 @@ dependencies = [
  "num-traits 0.2.18",
  "serde",
  "wasm-bindgen",
- "windows-targets 0.52.4",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -948,9 +952,9 @@ dependencies = [
 
 [[package]]
 name = "clipboard-win"
-version = "5.3.0"
+version = "5.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d517d4b86184dbb111d3556a10f1c8a04da7428d2987bf1081602bf11c3aa9ee"
+checksum = "79f4473f5144e20d9aceaf2972478f06ddf687831eafeeb434fbaf0acc4144ad"
 dependencies = [
  "error-code",
 ]
@@ -1020,7 +1024,7 @@ dependencies = [
  "block",
  "cocoa-foundation",
  "core-foundation 0.9.4",
- "core-graphics 0.23.1",
+ "core-graphics 0.23.2",
  "foreign-types 0.5.0",
  "libc",
  "objc",
@@ -1072,7 +1076,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d375883580a668c7481ea6631fc1a8863e33cc335bf56bfad8d7e6d4b04b13a5"
 dependencies = [
  "com_macros_support",
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "syn 1.0.109",
 ]
 
@@ -1082,16 +1086,16 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad899a1087a9296d5644792d7cb72b8e34c1bec8e7d4fbc002230169a6e8710c"
 dependencies = [
- "proc-macro2 1.0.79",
- "quote 1.0.35",
+ "proc-macro2 1.0.81",
+ "quote 1.0.36",
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "combine"
-version = "4.6.6"
+version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35ed6e9d84f0b51a7f52daf1c7d71dd136fd7a3f41a8462b8cdb8c78d920fad4"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes 1.6.0",
  "memchr",
@@ -1099,9 +1103,9 @@ dependencies = [
 
 [[package]]
 name = "concurrent-queue"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16048cd947b08fa32c24458a22f5dc5e835264f689f4f5653210c69fd107363"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1174,9 +1178,9 @@ dependencies = [
 
 [[package]]
 name = "core-graphics"
-version = "0.23.1"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "970a29baf4110c26fedbc7f82107d42c23f7e88e404c4577ed73fe99ff85a212"
+checksum = "c07782be35f9e1140080c6b96f0d44b739e2278479f64e02fdab4e32dfd8b081"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation 0.9.4",
@@ -1349,12 +1353,12 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad291aa74992b9b7a7e88c38acbbf6ad7e107f1d90ee8775b7bc1fc3394f485c"
+checksum = "edb49164822f3ee45b17acd4a208cfc1251410cf0cad9a833234c9890774dd9f"
 dependencies = [
- "quote 1.0.35",
- "syn 2.0.57",
+ "quote 1.0.36",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -1374,7 +1378,7 @@ dependencies = [
  "openssl-probe",
  "openssl-sys",
  "schannel",
- "socket2 0.5.6",
+ "socket2 0.5.7",
  "windows-sys 0.52.0",
 ]
 
@@ -1455,8 +1459,8 @@ checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2 1.0.79",
- "quote 1.0.35",
+ "proc-macro2 1.0.81",
+ "quote 1.0.36",
  "strsim 0.10.0",
  "syn 1.0.109",
 ]
@@ -1468,7 +1472,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
 dependencies = [
  "darling_core",
- "quote 1.0.35",
+ "quote 1.0.36",
  "syn 1.0.109",
 ]
 
@@ -1479,17 +1483,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
 dependencies = [
  "cfg-if 1.0.0",
- "hashbrown 0.14.3",
- "lock_api 0.4.11",
+ "hashbrown 0.14.5",
+ "lock_api 0.4.12",
  "once_cell",
- "parking_lot_core 0.9.9",
+ "parking_lot_core 0.9.10",
 ]
 
 [[package]]
 name = "data-encoding"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e962a19be5cfc3f3bf6dd8f61eb50107f356ad6270fbb3ed41476571db78be5"
+checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
 
 [[package]]
 name = "deflate"
@@ -1614,9 +1618,9 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
- "proc-macro2 1.0.79",
- "quote 1.0.35",
- "syn 2.0.57",
+ "proc-macro2 1.0.81",
+ "quote 1.0.36",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -1630,9 +1634,9 @@ dependencies = [
 
 [[package]]
 name = "downcast-rs"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "drm"
@@ -1644,7 +1648,7 @@ dependencies = [
  "bytemuck",
  "drm-ffi",
  "drm-fourcc",
- "rustix 0.38.32",
+ "rustix 0.38.34",
 ]
 
 [[package]]
@@ -1654,7 +1658,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41334f8405792483e32ad05fbb9c5680ff4e84491883d2947a4757dc54cb2ac6"
 dependencies = [
  "drm-sys",
- "rustix 0.38.32",
+ "rustix 0.38.34",
 ]
 
 [[package]]
@@ -1735,9 +1739,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
+checksum = "a47c1c47d2f5964e29c61246e81db715514cd532db6b5116a25ea3c03d6780a2"
 
 [[package]]
 name = "embed-resource"
@@ -1760,9 +1764,9 @@ checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.33"
+version = "0.8.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
+checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -1847,9 +1851,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b5fb89194fa3cad959b833185b3063ba881dbfc7030680b314250779fb4cc91"
+checksum = "6d9944b8ca13534cdfb2800775f8dd4902ff3fc75a50101466decadfdf322a24"
 dependencies = [
  "concurrent-queue",
  "parking",
@@ -1868,11 +1872,11 @@ dependencies = [
 
 [[package]]
 name = "event-listener-strategy"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "332f51cb23d20b0de8458b86580878211da09bcd4503cb579c225b3d124cabb3"
+checksum = "0f214dc438f977e6d4e3500aaa277f5ad94ca83fbbd9b1a15713ce2344ccc5a1"
 dependencies = [
- "event-listener 5.2.0",
+ "event-listener 5.3.0",
  "pin-project-lite 0.2.14",
 ]
 
@@ -1903,9 +1907,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.0.2"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984"
+checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 
 [[package]]
 name = "fdeflate"
@@ -1939,9 +1943,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.28"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
+checksum = "5f54427cfd1c7829e2a139fcefea601bf088ebca651d2bf53ebc600eac295dae"
 dependencies = [
  "crc32fast",
  "miniz_oxide 0.7.2",
@@ -2047,9 +2051,12 @@ dependencies = [
 
 [[package]]
 name = "font-types"
-version = "0.4.3"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b7f6040d337bd44434ab21fc6509154edf2cece88b23758d9d64654c4e7730b"
+checksum = "bdf6aa1de86490d8e39e04589bd04eb5953cc2a5ef0c25e389e807f44fd24e41"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "fontconfig-parser"
@@ -2099,9 +2106,9 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
- "proc-macro2 1.0.79",
- "quote 1.0.35",
- "syn 2.0.57",
+ "proc-macro2 1.0.81",
+ "quote 1.0.36",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -2127,9 +2134,9 @@ dependencies = [
 
 [[package]]
 name = "freetype"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efc8599a3078adf8edeb86c71e9f8fa7d88af5ca31e806a867756081f90f5d83"
+checksum = "5a440748e063798e4893ceb877151e84acef9bea9a8c6800645cf3f1b3a7806e"
 dependencies = [
  "freetype-sys",
  "libc",
@@ -2137,9 +2144,9 @@ dependencies = [
 
 [[package]]
 name = "freetype-sys"
-version = "0.19.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66ee28c39a43d89fbed8b4798fb4ba56722cfd2b5af81f9326c27614ba88ecd5"
+checksum = "0e7edc5b9669349acfda99533e9e0bcf26a51862ab43b08ee7745c55d28eb134"
 dependencies = [
  "cc",
  "libc",
@@ -2254,7 +2261,7 @@ version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52527eb5074e35e9339c6b4e8d12600c7128b68fb25dcb9fa9dec18f7c25f3a5"
 dependencies = [
- "fastrand 2.0.2",
+ "fastrand 2.1.0",
  "futures-core",
  "futures-io",
  "parking",
@@ -2267,9 +2274,9 @@ version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
- "proc-macro2 1.0.79",
- "quote 1.0.35",
- "syn 2.0.57",
+ "proc-macro2 1.0.81",
+ "quote 1.0.36",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -2389,9 +2396,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.12"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
+checksum = "94b22e06ecb0110981051723910cbf0b5f5e09a2062dd7663334ee79a9d1286c"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -2579,7 +2586,7 @@ checksum = "cc11df1ace8e7e564511f53af41f3e42ddc95b56fd07b3f4445d2a6048bc682c"
 dependencies = [
  "bitflags 2.5.0",
  "gpu-descriptor-types",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -2696,8 +2703,8 @@ dependencies = [
 
 [[package]]
 name = "grin_api"
-version = "5.3.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin?branch=master#43b43d9749ea14a33e90da1e66a25197bcd91450"
+version = "5.3.0"
+source = "git+https://github.com/mimblewimble/grin?branch=master#163ca397f4a890159440c74b1b20dfdba3b11b75"
 dependencies = [
  "bytes 0.5.6",
  "easy-jsonrpc-mw",
@@ -2728,8 +2735,8 @@ dependencies = [
 
 [[package]]
 name = "grin_chain"
-version = "5.3.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin?branch=master#43b43d9749ea14a33e90da1e66a25197bcd91450"
+version = "5.3.0"
+source = "git+https://github.com/mimblewimble/grin?branch=master#163ca397f4a890159440c74b1b20dfdba3b11b75"
 dependencies = [
  "bit-vec",
  "bitflags 1.3.2",
@@ -2751,8 +2758,8 @@ dependencies = [
 
 [[package]]
 name = "grin_config"
-version = "5.3.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin?branch=master#43b43d9749ea14a33e90da1e66a25197bcd91450"
+version = "5.3.0"
+source = "git+https://github.com/mimblewimble/grin?branch=master#163ca397f4a890159440c74b1b20dfdba3b11b75"
 dependencies = [
  "dirs 2.0.2",
  "grin_core",
@@ -2767,8 +2774,8 @@ dependencies = [
 
 [[package]]
 name = "grin_core"
-version = "5.3.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin?branch=master#43b43d9749ea14a33e90da1e66a25197bcd91450"
+version = "5.3.0"
+source = "git+https://github.com/mimblewimble/grin?branch=master#163ca397f4a890159440c74b1b20dfdba3b11b75"
 dependencies = [
  "blake2-rfc",
  "byteorder",
@@ -2793,8 +2800,8 @@ dependencies = [
 
 [[package]]
 name = "grin_keychain"
-version = "5.3.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin?branch=master#43b43d9749ea14a33e90da1e66a25197bcd91450"
+version = "5.3.0"
+source = "git+https://github.com/mimblewimble/grin?branch=master#163ca397f4a890159440c74b1b20dfdba3b11b75"
 dependencies = [
  "blake2-rfc",
  "byteorder",
@@ -2815,8 +2822,8 @@ dependencies = [
 
 [[package]]
 name = "grin_p2p"
-version = "5.3.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin?branch=master#43b43d9749ea14a33e90da1e66a25197bcd91450"
+version = "5.3.0"
+source = "git+https://github.com/mimblewimble/grin?branch=master#163ca397f4a890159440c74b1b20dfdba3b11b75"
 dependencies = [
  "bitflags 1.3.2",
  "bytes 0.5.6",
@@ -2837,8 +2844,8 @@ dependencies = [
 
 [[package]]
 name = "grin_pool"
-version = "5.3.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin?branch=master#43b43d9749ea14a33e90da1e66a25197bcd91450"
+version = "5.3.0"
+source = "git+https://github.com/mimblewimble/grin?branch=master#163ca397f4a890159440c74b1b20dfdba3b11b75"
 dependencies = [
  "blake2-rfc",
  "chrono",
@@ -2854,15 +2861,14 @@ dependencies = [
 
 [[package]]
 name = "grin_secp256k1zkp"
-version = "0.7.12"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b04798e32404c0af082b6a209ad4df1ab1d9ec3a5a5056f284cfa32f74e59ce6"
+checksum = "447e2e66d2f6cc14d49afdad59a5b26f47654c845483dbb3f3403ace0dbb94b4"
 dependencies = [
  "arrayvec 0.3.25",
  "cc",
  "libc",
  "rand 0.5.6",
- "rustc-serialize",
  "serde",
  "serde_json",
  "zeroize",
@@ -2870,8 +2876,8 @@ dependencies = [
 
 [[package]]
 name = "grin_servers"
-version = "5.3.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin?branch=master#43b43d9749ea14a33e90da1e66a25197bcd91450"
+version = "5.3.0"
+source = "git+https://github.com/mimblewimble/grin?branch=master#163ca397f4a890159440c74b1b20dfdba3b11b75"
 dependencies = [
  "chrono",
  "fs2",
@@ -2900,8 +2906,8 @@ dependencies = [
 
 [[package]]
 name = "grin_store"
-version = "5.3.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin?branch=master#43b43d9749ea14a33e90da1e66a25197bcd91450"
+version = "5.3.0"
+source = "git+https://github.com/mimblewimble/grin?branch=master#163ca397f4a890159440c74b1b20dfdba3b11b75"
 dependencies = [
  "byteorder",
  "croaring",
@@ -2919,8 +2925,8 @@ dependencies = [
 
 [[package]]
 name = "grin_util"
-version = "5.3.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin?branch=master#43b43d9749ea14a33e90da1e66a25197bcd91450"
+version = "5.3.0"
+source = "git+https://github.com/mimblewimble/grin?branch=master#163ca397f4a890159440c74b1b20dfdba3b11b75"
 dependencies = [
  "backtrace",
  "base64 0.12.3",
@@ -2940,8 +2946,8 @@ dependencies = [
 
 [[package]]
 name = "grin_wallet"
-version = "5.2.0-beta.1"
-source = "git+https://github.com/mimblewimble/grin-wallet?branch=contracts#6f226ea3e26917a472f24ccd677993439a142695"
+version = "5.3.0"
+source = "git+https://github.com/mimblewimble/grin-wallet?branch=contracts#57bf8be0cbae42893b4b53211f1effa77fc71437"
 dependencies = [
  "built",
  "clap",
@@ -2967,8 +2973,8 @@ dependencies = [
 
 [[package]]
 name = "grin_wallet_api"
-version = "5.2.0-beta.1"
-source = "git+https://github.com/mimblewimble/grin-wallet?branch=contracts#6f226ea3e26917a472f24ccd677993439a142695"
+version = "5.3.0"
+source = "git+https://github.com/mimblewimble/grin-wallet?branch=contracts#57bf8be0cbae42893b4b53211f1effa77fc71437"
 dependencies = [
  "base64 0.12.3",
  "chrono",
@@ -2992,8 +2998,8 @@ dependencies = [
 
 [[package]]
 name = "grin_wallet_config"
-version = "5.2.0-beta.1"
-source = "git+https://github.com/mimblewimble/grin-wallet?branch=contracts#6f226ea3e26917a472f24ccd677993439a142695"
+version = "5.3.0"
+source = "git+https://github.com/mimblewimble/grin-wallet?branch=contracts#57bf8be0cbae42893b4b53211f1effa77fc71437"
 dependencies = [
  "dirs 2.0.2",
  "grin_core",
@@ -3007,8 +3013,8 @@ dependencies = [
 
 [[package]]
 name = "grin_wallet_controller"
-version = "5.2.0-beta.1"
-source = "git+https://github.com/mimblewimble/grin-wallet?branch=contracts#6f226ea3e26917a472f24ccd677993439a142695"
+version = "5.3.0"
+source = "git+https://github.com/mimblewimble/grin-wallet?branch=contracts#57bf8be0cbae42893b4b53211f1effa77fc71437"
 dependencies = [
  "chrono",
  "easy-jsonrpc-mw",
@@ -3041,8 +3047,8 @@ dependencies = [
 
 [[package]]
 name = "grin_wallet_impls"
-version = "5.2.0-beta.1"
-source = "git+https://github.com/mimblewimble/grin-wallet?branch=contracts#6f226ea3e26917a472f24ccd677993439a142695"
+version = "5.3.0"
+source = "git+https://github.com/mimblewimble/grin-wallet?branch=contracts#57bf8be0cbae42893b4b53211f1effa77fc71437"
 dependencies = [
  "base64 0.12.3",
  "blake2-rfc",
@@ -3080,8 +3086,8 @@ dependencies = [
 
 [[package]]
 name = "grin_wallet_libwallet"
-version = "5.2.0-beta.1"
-source = "git+https://github.com/mimblewimble/grin-wallet?branch=contracts#6f226ea3e26917a472f24ccd677993439a142695"
+version = "5.3.0"
+source = "git+https://github.com/mimblewimble/grin-wallet?branch=contracts#57bf8be0cbae42893b4b53211f1effa77fc71437"
 dependencies = [
  "age",
  "base64 0.9.3",
@@ -3121,8 +3127,8 @@ dependencies = [
 
 [[package]]
 name = "grin_wallet_util"
-version = "5.2.0-beta.1"
-source = "git+https://github.com/mimblewimble/grin-wallet?branch=contracts#6f226ea3e26917a472f24ccd677993439a142695"
+version = "5.3.0"
+source = "git+https://github.com/mimblewimble/grin-wallet?branch=contracts#57bf8be0cbae42893b4b53211f1effa77fc71437"
 dependencies = [
  "data-encoding",
  "ed25519-dalek",
@@ -3184,9 +3190,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fbd2820c5e49886948654ab546d0688ff24530286bdcf8fca3cefb16d4618eb"
+checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
 dependencies = [
  "bytes 1.6.0",
  "fnv",
@@ -3203,9 +3209,9 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5eceaaeec696539ddaf7b333340f1af35a5aa87ae3e4f3ead0532f72affab2e"
+checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
 dependencies = [
  "cfg-if 1.0.0",
  "crunchy",
@@ -3219,9 +3225,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.14.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
  "allocator-api2",
@@ -3403,14 +3409,14 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.3.25",
+ "h2 0.3.26",
  "http",
  "http-body 0.4.6",
  "httparse",
  "httpdate 1.0.3",
  "itoa 1.0.11",
  "pin-project-lite 0.2.14",
- "socket2 0.5.6",
+ "socket2 0.5.7",
  "tokio 1.37.0",
  "tower-service",
  "tracing",
@@ -3517,7 +3523,7 @@ dependencies = [
  "intl-memoizer",
  "lazy_static",
  "log",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.2",
  "rust-embed",
  "thiserror",
  "unic-langid",
@@ -3538,10 +3544,10 @@ dependencies = [
  "i18n-embed",
  "lazy_static",
  "proc-macro-error",
- "proc-macro2 1.0.79",
- "quote 1.0.35",
+ "proc-macro2 1.0.81",
+ "quote 1.0.36",
  "strsim 0.10.0",
- "syn 2.0.57",
+ "syn 2.0.60",
  "unic-langid",
 ]
 
@@ -3553,9 +3559,9 @@ checksum = "81093c4701672f59416582fe3145676126fd23ba5db910acad0793c1108aaa58"
 dependencies = [
  "find-crate",
  "i18n-config",
- "proc-macro2 1.0.79",
- "quote 1.0.35",
- "syn 2.0.57",
+ "proc-macro2 1.0.81",
+ "quote 1.0.36",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -3615,7 +3621,7 @@ dependencies = [
  "log",
  "num-traits 0.2.18",
  "palette",
- "raw-window-handle 0.6.0",
+ "raw-window-handle 0.6.1",
  "smol_str",
  "thiserror",
  "web-time",
@@ -3652,7 +3658,7 @@ dependencies = [
  "log",
  "lyon_path",
  "once_cell",
- "raw-window-handle 0.6.0",
+ "raw-window-handle 0.6.1",
  "rustc-hash",
  "thiserror",
  "unicode-segmentation",
@@ -3680,7 +3686,7 @@ checksum = "a79f852c01cc6d61663c94379cb3974ac3ad315a28c504e847d573e094f46822"
 dependencies = [
  "iced_core",
  "iced_futures",
- "raw-window-handle 0.6.0",
+ "raw-window-handle 0.6.1",
  "thiserror",
 ]
 
@@ -3840,7 +3846,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -4019,9 +4025,9 @@ checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "jobserver"
-version = "0.1.28"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab46a6e9526ddef3ae7f787c06f0f2600639ba80ea3eade3d8e670a2230f51d6"
+checksum = "d2b099aaa34a9751c5bf0878add70444e1ed2dd73f347be99003d4577277de6e"
 dependencies = [
  "libc",
 ]
@@ -4137,9 +4143,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.154"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "ae743338b92ff9146ce83992f766a31066a91a8c84a45e0e9f21e7cf6de6d346"
 
 [[package]]
 name = "libgit2-sys"
@@ -4180,7 +4186,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
 dependencies = [
  "cfg-if 1.0.0",
- "windows-targets 0.52.4",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -4191,9 +4197,9 @@ checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
 name = "libnghttp2-sys"
-version = "0.1.9+1.58.0"
+version = "0.1.10+1.61.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b57e858af2798e167e709b9d969325b6d8e9d50232fcbc494d7d54f976854a64"
+checksum = "959c25552127d2e1fa72f0e52548ec04fc386e827ba71a7bd01db46a447dc135"
 dependencies = [
  "cc",
  "libc",
@@ -4290,9 +4296,9 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
 dependencies = [
  "autocfg 1.2.0",
  "scopeguard",
@@ -4355,7 +4361,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3262e75e648fce39813cb56ac41f3c3e3f65217ebf3844d818d1f9398cfb0dc"
 dependencies = [
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -4410,9 +4416,9 @@ dependencies = [
 
 [[package]]
 name = "lyon_tessellation"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c7c67b5bc8123b352b2e7e742b47d1f236a13fe77619433be9568fbd888e9c0"
+checksum = "4470bd0b1f29eda66068ab1fd47719facda0a136b829bcca69287ed0ac40a134"
 dependencies = [
  "float_next_after",
  "lyon_path",
@@ -4707,7 +4713,7 @@ dependencies = [
  "log",
  "ndk-sys",
  "num_enum",
- "raw-window-handle 0.6.0",
+ "raw-window-handle 0.6.1",
  "thiserror",
 ]
 
@@ -4918,9 +4924,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "681030a937600a36906c185595136d26abfebb4aa9c65701cefcaf8578bb982b"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2 1.0.79",
- "quote 1.0.35",
- "syn 2.0.57",
+ "proc-macro2 1.0.81",
+ "quote 1.0.36",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -4946,9 +4952,9 @@ dependencies = [
 
 [[package]]
 name = "objc-sys"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c71324e4180d0899963fc83d9d241ac39e699609fc1025a850aadac8257459"
+checksum = "da284c198fb9b7b0603f8635185e85fbd5b64ee154b1ed406d489077de2d6d60"
 
 [[package]]
 name = "objc2"
@@ -5057,9 +5063,9 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
- "proc-macro2 1.0.79",
- "quote 1.0.35",
- "syn 2.0.57",
+ "proc-macro2 1.0.81",
+ "quote 1.0.36",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -5109,9 +5115,9 @@ dependencies = [
 
 [[package]]
 name = "palette"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebfc23a4b76642983d57e4ad00bb4504eb30a8ce3c70f4aee1f725610e36d97a"
+checksum = "4cbf71184cc5ecc2e4e1baccdb21026c20e5fc3dcf63028a086131b3ab00b6e6"
 dependencies = [
  "approx",
  "fast-srgb8",
@@ -5121,13 +5127,14 @@ dependencies = [
 
 [[package]]
 name = "palette_derive"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8890702dbec0bad9116041ae586f84805b13eecd1d8b1df27c29998a9969d6d"
+checksum = "f5030daf005bface118c096f510ffb781fc28f9ab6a32ab224d8631be6851d30"
 dependencies = [
- "proc-macro2 1.0.79",
- "quote 1.0.35",
- "syn 2.0.57",
+ "by_address",
+ "proc-macro2 1.0.81",
+ "quote 1.0.36",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -5165,18 +5172,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
- "lock_api 0.4.11",
+ "lock_api 0.4.12",
  "parking_lot_core 0.8.6",
 ]
 
 [[package]]
 name = "parking_lot"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+checksum = "7e4af0ca4f6caed20e900d564c242b8e5d4903fdacf31d3daf527b66fe6f42fb"
 dependencies = [
- "lock_api 0.4.11",
- "parking_lot_core 0.9.9",
+ "lock_api 0.4.12",
+ "parking_lot_core 0.9.10",
 ]
 
 [[package]]
@@ -5209,15 +5216,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.9"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "redox_syscall 0.4.1",
+ "redox_syscall 0.5.1",
  "smallvec",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -5261,9 +5268,9 @@ dependencies = [
 
 [[package]]
 name = "pathfinder_simd"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0444332826c70dc47be74a7c6a5fc44e23a7905ad6858d4162b658320455ef93"
+checksum = "ebf45976c56919841273f2a0fc684c28437e2f304e264557d9c72be5d5a718be"
 dependencies = [
  "rustc_version",
 ]
@@ -5363,9 +5370,9 @@ checksum = "3444646e286606587e49f3bcf1679b8cef1dc2c5ecc29ddacaffc305180d464b"
 dependencies = [
  "phf_generator 0.11.2",
  "phf_shared 0.11.2",
- "proc-macro2 1.0.79",
- "quote 1.0.35",
- "syn 2.0.57",
+ "proc-macro2 1.0.81",
+ "quote 1.0.36",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -5401,9 +5408,9 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
- "proc-macro2 1.0.79",
- "quote 1.0.35",
- "syn 2.0.57",
+ "proc-macro2 1.0.81",
+ "quote 1.0.36",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -5431,7 +5438,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "668d31b1c4eba19242f2088b2bf3316b82ca31082a8335764db4e083db7485d4"
 dependencies = [
  "atomic-waker",
- "fastrand 2.0.2",
+ "fastrand 2.1.0",
  "futures-io",
 ]
 
@@ -5543,15 +5550,15 @@ dependencies = [
 
 [[package]]
 name = "polling"
-version = "3.6.0"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c976a60b2d7e99d6f229e414670a9b85d13ac305cc6d1e9c134de58c5aaaf6"
+checksum = "645493cf344456ef24219d02a768cf1fb92ddf8c92161679ae3d91b91a637be3"
 dependencies = [
  "cfg-if 1.0.0",
  "concurrent-queue",
  "hermit-abi 0.3.9",
  "pin-project-lite 0.2.14",
- "rustix 0.38.32",
+ "rustix 0.38.34",
  "tracing",
  "windows-sys 0.52.0",
 ]
@@ -5609,8 +5616,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.79",
- "quote 1.0.35",
+ "proc-macro2 1.0.81",
+ "quote 1.0.36",
  "syn 1.0.109",
  "version_check",
 ]
@@ -5621,8 +5628,8 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.79",
- "quote 1.0.35",
+ "proc-macro2 1.0.81",
+ "quote 1.0.36",
  "version_check",
 ]
 
@@ -5637,9 +5644,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.79"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
+checksum = "3d1597b0c024618f09a9c3b8655b7e430397a36d23fdafec26d6965e9eec3eba"
 dependencies = [
  "unicode-ident",
 ]
@@ -5682,11 +5689,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.35"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
 ]
 
 [[package]]
@@ -5805,7 +5812,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.12",
+ "getrandom 0.2.14",
 ]
 
 [[package]]
@@ -5912,9 +5919,9 @@ dependencies = [
 
 [[package]]
 name = "raw-window-handle"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42a9830a0e1b9fb145ebb365b8bc4ccd75f290f98c0247deafbbe2c75cefb544"
+checksum = "8cc3bcbdb1ddfc11e700e62968e6b4cc9c75bb466464ad28fb61c5b2c964418b"
 
 [[package]]
 name = "rayon"
@@ -5947,10 +5954,11 @@ dependencies = [
 
 [[package]]
 name = "read-fonts"
-version = "0.16.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81c524658d3b77930a391f559756d91dbe829ab6cf4687083f615d395df99722"
+checksum = "af4749db2bd1c853db31a7ae5ee2fc6c30bbddce353ea8fedf673fed187c68c7"
 dependencies = [
+ "bytemuck",
  "font-types",
 ]
 
@@ -5988,6 +5996,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469052894dcb553421e483e4209ee581a45100d31b4018de03e5a7ad86374a7e"
+dependencies = [
+ "bitflags 2.5.0",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6004,7 +6021,7 @@ version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891"
 dependencies = [
- "getrandom 0.2.12",
+ "getrandom 0.2.14",
  "libredox 0.1.3",
  "thiserror",
 ]
@@ -6095,7 +6112,7 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2 0.3.25",
+ "h2 0.3.26",
  "http",
  "http-body 0.4.6",
  "hyper 0.14.28",
@@ -6227,10 +6244,10 @@ version = "6.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49b94b81e5b2c284684141a2fb9e2a31be90638caf040bf9afbc5a0416afe1ac"
 dependencies = [
- "proc-macro2 1.0.79",
- "quote 1.0.35",
+ "proc-macro2 1.0.81",
+ "quote 1.0.36",
  "rust-embed-utils",
- "syn 2.0.57",
+ "syn 2.0.60",
  "walkdir",
 ]
 
@@ -6257,12 +6274,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
-name = "rustc-serialize"
-version = "0.3.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe834bc780604f4674073badbad26d7219cadfb4a2275802db12cbae17498401"
-
-[[package]]
 name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6287,9 +6298,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.32"
+version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65e04861e65f21776e67888bfbea442b3642beaa0138fdb1dd7a84a52dffdb89"
+checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
 dependencies = [
  "bitflags 2.5.0",
  "errno",
@@ -6347,9 +6358,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
+checksum = "80af6f9131f277a45a3fba6ce8e2258037bb0477a67e610d3c1fe046ab31de47"
 
 [[package]]
 name = "rustybuzz"
@@ -6591,9 +6602,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.197"
+version = "1.0.199"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
+checksum = "0c9f6e76df036c77cd94996771fb40db98187f096dd0b9af39c6c6e452ba966a"
 dependencies = [
  "serde_derive",
 ]
@@ -6610,20 +6621,20 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.197"
+version = "1.0.199"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
+checksum = "11bd257a6541e141e42ca6d24ae26f7714887b47e89aa739099104c7e4d3b7fc"
 dependencies = [
- "proc-macro2 1.0.79",
- "quote 1.0.35",
- "syn 2.0.57",
+ "proc-macro2 1.0.81",
+ "quote 1.0.36",
+ "syn 2.0.60",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.115"
+version = "1.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd"
+checksum = "3e17db7126d17feb94eb3fad46bf1a96b034e8aacbc2e775fe81505f8b0b2813"
 dependencies = [
  "itoa 1.0.11",
  "ryu",
@@ -6669,8 +6680,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e182d6ec6f05393cc0e5ed1bf81ad6db3a8feedf8ee515ecdd369809bcce8082"
 dependencies = [
  "darling",
- "proc-macro2 1.0.79",
- "quote 1.0.35",
+ "proc-macro2 1.0.81",
+ "quote 1.0.36",
  "syn 1.0.109",
 ]
 
@@ -6725,9 +6736,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
 dependencies = [
  "libc",
 ]
@@ -6813,7 +6824,7 @@ dependencies = [
  "libc",
  "log",
  "memmap2 0.9.4",
- "rustix 0.38.32",
+ "rustix 0.38.34",
  "thiserror",
  "wayland-backend",
  "wayland-client",
@@ -6868,9 +6879,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.6"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ffd9c0a93b7543e062e759284fcf5f5e3b098501104bfbdde4d404db792871"
+checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -6878,25 +6889,25 @@ dependencies = [
 
 [[package]]
 name = "softbuffer"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "071916a85d1db274b4ed57af3a14afb66bd836ae7f82ebb6f1fd3455107830d9"
+checksum = "61d5d17f23326fe0d9b0af282f73f3af666699420fd5f42629efd9c6e7dc166f"
 dependencies = [
  "as-raw-xcb-connection",
  "bytemuck",
  "cfg_aliases 0.2.0",
  "cocoa 0.25.0",
- "core-graphics 0.23.1",
+ "core-graphics 0.23.2",
  "drm",
- "fastrand 2.0.2",
+ "fastrand 2.1.0",
  "foreign-types 0.5.0",
  "js-sys",
  "log",
  "memmap2 0.9.4",
  "objc",
- "raw-window-handle 0.6.0",
- "redox_syscall 0.4.1",
- "rustix 0.38.32",
+ "raw-window-handle 0.6.1",
+ "redox_syscall 0.5.1",
+ "rustix 0.38.34",
  "tiny-xlib",
  "wasm-bindgen",
  "wayland-backend",
@@ -6919,7 +6930,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b9eb1a2f4c41445a3a0ff9abc5221c5fcd28e1f13cd7c0397706f9ac938ddb0"
 dependencies = [
- "lock_api 0.4.11",
+ "lock_api 0.4.12",
 ]
 
 [[package]]
@@ -6980,8 +6991,8 @@ checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
 dependencies = [
  "heck",
  "proc-macro-error",
- "proc-macro2 1.0.79",
- "quote 1.0.35",
+ "proc-macro2 1.0.81",
+ "quote 1.0.36",
  "syn 1.0.109",
 ]
 
@@ -7004,8 +7015,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87c85aa3f8ea653bfd3ddf25f7ee357ee4d204731f6aa9ad04002306f6e2774c"
 dependencies = [
  "heck",
- "proc-macro2 1.0.79",
- "quote 1.0.35",
+ "proc-macro2 1.0.81",
+ "quote 1.0.36",
  "syn 1.0.109",
 ]
 
@@ -7016,8 +7027,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d06aaeeee809dbc59eb4556183dd927df67db1540de5be8d3ec0b6636358a5ec"
 dependencies = [
  "heck",
- "proc-macro2 1.0.79",
- "quote 1.0.35",
+ "proc-macro2 1.0.81",
+ "quote 1.0.36",
  "syn 1.0.109",
 ]
 
@@ -7041,9 +7052,9 @@ checksum = "f83ba502a3265efb76efb89b0a2f7782ad6f2675015d4ce37e4b547dda42b499"
 
 [[package]]
 name = "swash"
-version = "0.1.13"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9af636fb90d39858650cae1088a37e2862dab4e874a0bb49d6dfb5b2dacf0e24"
+checksum = "06ec889a8e0a6fcb91041996c8f1f6be0fe1a09e94478785e07c32ce2bca2d2b"
 dependencies = [
  "read-fonts",
  "yazi",
@@ -7067,19 +7078,19 @@ version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
- "proc-macro2 1.0.79",
- "quote 1.0.35",
+ "proc-macro2 1.0.81",
+ "quote 1.0.36",
  "unicode-ident",
 ]
 
 [[package]]
 name = "syn"
-version = "2.0.57"
+version = "2.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11a6ae1e52eb25aab8f3fb9fca13be982a373b8f1157ca14b897a825ba4a2d35"
+checksum = "909518bc7b1c9b779f1bbf07f2929d35af9f0f37e47c6e9ef7f9dddc1e1821f3"
 dependencies = [
- "proc-macro2 1.0.79",
- "quote 1.0.35",
+ "proc-macro2 1.0.81",
+ "quote 1.0.36",
  "unicode-ident",
 ]
 
@@ -7170,8 +7181,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
 dependencies = [
  "cfg-if 1.0.0",
- "fastrand 2.0.2",
- "rustix 0.38.32",
+ "fastrand 2.1.0",
+ "rustix 0.38.34",
  "windows-sys 0.52.0",
 ]
 
@@ -7229,22 +7240,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.58"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
+checksum = "f0126ad08bff79f29fc3ae6a55cc72352056dfff61e3ff8bb7129476d44b23aa"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.58"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
+checksum = "d1cd413b5d558b4c5bf3680e324a6fa5014e7b7c067a51e69dbdf47eb7148b66"
 dependencies = [
- "proc-macro2 1.0.79",
- "quote 1.0.35",
- "syn 2.0.57",
+ "proc-macro2 1.0.81",
+ "quote 1.0.36",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -7407,7 +7418,7 @@ dependencies = [
  "mio 0.8.11",
  "num_cpus",
  "pin-project-lite 0.2.14",
- "socket2 0.5.6",
+ "socket2 0.5.7",
  "windows-sys 0.48.0",
 ]
 
@@ -7427,8 +7438,8 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e44da00bfc73a25f814cd8d7e57a68a5c31b74b3152a0a1d1f590c97ed06265a"
 dependencies = [
- "proc-macro2 1.0.79",
- "quote 1.0.35",
+ "proc-macro2 1.0.81",
+ "quote 1.0.36",
  "syn 1.0.109",
 ]
 
@@ -7549,7 +7560,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.9",
+ "toml_edit 0.22.12",
 ]
 
 [[package]]
@@ -7574,15 +7585,15 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.9"
+version = "0.22.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e40bb779c5187258fd7aad0eb68cb8706a0a81fa712fbea808ab43c4b8374c4"
+checksum = "d3328d4f68a705b2a4498da1d580585d39a6510f98318a2cec3018a7ec61ddef"
 dependencies = [
  "indexmap 2.2.6",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.6.5",
+ "winnow 0.6.7",
 ]
 
 [[package]]
@@ -7609,9 +7620,9 @@ version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
- "proc-macro2 1.0.79",
- "quote 1.0.35",
- "syn 2.0.57",
+ "proc-macro2 1.0.81",
+ "quote 1.0.36",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -7774,9 +7785,9 @@ checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
+checksum = "68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6"
 
 [[package]]
 name = "unicode-xid"
@@ -7838,7 +7849,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
- "getrandom 0.2.12",
+ "getrandom 0.2.14",
  "serde",
 ]
 
@@ -7956,9 +7967,9 @@ dependencies = [
  "bumpalo",
  "log",
  "once_cell",
- "proc-macro2 1.0.79",
- "quote 1.0.35",
- "syn 2.0.57",
+ "proc-macro2 1.0.81",
+ "quote 1.0.36",
+ "syn 2.0.60",
  "wasm-bindgen-shared",
 ]
 
@@ -7980,7 +7991,7 @@ version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
 dependencies = [
- "quote 1.0.35",
+ "quote 1.0.36",
  "wasm-bindgen-macro-support",
 ]
 
@@ -7990,9 +8001,9 @@ version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
- "proc-macro2 1.0.79",
- "quote 1.0.35",
- "syn 2.0.57",
+ "proc-macro2 1.0.81",
+ "quote 1.0.36",
+ "syn 2.0.60",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -8026,7 +8037,7 @@ checksum = "9d50fa61ce90d76474c87f5fc002828d81b32677340112b4ef08079a9d459a40"
 dependencies = [
  "cc",
  "downcast-rs",
- "rustix 0.38.32",
+ "rustix 0.38.34",
  "scoped-tls",
  "smallvec",
  "wayland-sys",
@@ -8039,7 +8050,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82fb96ee935c2cea6668ccb470fb7771f6215d1691746c2d896b447a00ad3f1f"
 dependencies = [
  "bitflags 2.5.0",
- "rustix 0.38.32",
+ "rustix 0.38.34",
  "wayland-backend",
  "wayland-scanner",
 ]
@@ -8061,7 +8072,7 @@ version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71ce5fa868dd13d11a0d04c5e2e65726d0897be8de247c0c5a65886e283231ba"
 dependencies = [
- "rustix 0.38.32",
+ "rustix 0.38.34",
  "wayland-client",
  "xcursor",
 ]
@@ -8110,9 +8121,9 @@ version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b3a62929287001986fb58c789dce9b67604a397c15c611ad9f747300b6c283"
 dependencies = [
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quick-xml",
- "quote 1.0.35",
+ "quote 1.0.36",
 ]
 
 [[package]]
@@ -8184,9 +8195,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu"
-version = "0.19.3"
+version = "0.19.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4b1213b52478a7631d6e387543ed8f642bc02c578ef4e3b49aca2a29a7df0cb"
+checksum = "cbd7311dbd2abcfebaabf1841a2824ed7c8be443a0f29166e5d3c6a53a762c01"
 dependencies = [
  "arrayvec 0.7.4",
  "cfg-if 1.0.0",
@@ -8194,9 +8205,9 @@ dependencies = [
  "js-sys",
  "log",
  "naga",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.2",
  "profiling",
- "raw-window-handle 0.6.0",
+ "raw-window-handle 0.6.1",
  "smallvec",
  "static_assertions",
  "wasm-bindgen",
@@ -8209,9 +8220,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "0.19.3"
+version = "0.19.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9f6b033c2f00ae0bc8ea872c5989777c60bc241aac4e58b24774faa8b391f78"
+checksum = "28b94525fc99ba9e5c9a9e24764f2bc29bad0911a7446c12f446a8277369bf3a"
 dependencies = [
  "arrayvec 0.7.4",
  "bit-vec",
@@ -8222,9 +8233,9 @@ dependencies = [
  "log",
  "naga",
  "once_cell",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.2",
  "profiling",
- "raw-window-handle 0.6.0",
+ "raw-window-handle 0.6.1",
  "rustc-hash",
  "smallvec",
  "thiserror",
@@ -8235,9 +8246,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-hal"
-version = "0.19.3"
+version = "0.19.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f972c280505ab52ffe17e94a7413d9d54b58af0114ab226b9fc4999a47082e"
+checksum = "fc1a4924366df7ab41a5d8546d6534f1f33231aa5b3f72b9930e300f254e39c3"
 dependencies = [
  "android_system_properties",
  "arrayvec 0.7.4",
@@ -8264,10 +8275,10 @@ dependencies = [
  "ndk-sys",
  "objc",
  "once_cell",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.2",
  "profiling",
  "range-alloc",
- "raw-window-handle 0.6.0",
+ "raw-window-handle 0.6.1",
  "renderdoc-sys",
  "rustc-hash",
  "smallvec",
@@ -8298,14 +8309,14 @@ dependencies = [
  "either",
  "home",
  "once_cell",
- "rustix 0.38.32",
+ "rustix 0.38.34",
 ]
 
 [[package]]
 name = "widestring"
-version = "1.0.2"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "653f141f39ec16bba3c5abe400a0c60da7468261cc2cbf36805022876bc721a8"
+checksum = "7219d36b6eac893fa81e84ebe06485e7dcbb616177469b142df14f1f4deb1311"
 
 [[package]]
 name = "winapi"
@@ -8337,11 +8348,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
+checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
 dependencies = [
- "winapi 0.3.9",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8360,7 +8371,7 @@ dependencies = [
  "clipboard_macos",
  "clipboard_wayland",
  "clipboard_x11",
- "raw-window-handle 0.6.0",
+ "raw-window-handle 0.6.1",
  "thiserror",
 ]
 
@@ -8371,7 +8382,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
 dependencies = [
  "windows-core",
- "windows-targets 0.52.4",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -8380,7 +8391,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.4",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -8407,7 +8418,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.4",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -8442,17 +8453,18 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
+checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.4",
- "windows_aarch64_msvc 0.52.4",
- "windows_i686_gnu 0.52.4",
- "windows_i686_msvc 0.52.4",
- "windows_x86_64_gnu 0.52.4",
- "windows_x86_64_gnullvm 0.52.4",
- "windows_x86_64_msvc 0.52.4",
+ "windows_aarch64_gnullvm 0.52.5",
+ "windows_aarch64_msvc 0.52.5",
+ "windows_i686_gnu 0.52.5",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.5",
+ "windows_x86_64_gnu 0.52.5",
+ "windows_x86_64_gnullvm 0.52.5",
+ "windows_x86_64_msvc 0.52.5",
 ]
 
 [[package]]
@@ -8469,9 +8481,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
+checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -8487,9 +8499,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
+checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -8505,9 +8517,15 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
+checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -8523,9 +8541,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
+checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -8541,9 +8559,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
+checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -8559,9 +8577,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
+checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -8577,9 +8595,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
+checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
 
 [[package]]
 name = "winit"
@@ -8595,7 +8613,7 @@ dependencies = [
  "calloop",
  "cfg_aliases 0.1.1",
  "core-foundation 0.9.4",
- "core-graphics 0.23.1",
+ "core-graphics 0.23.2",
  "cursor-icon",
  "icrate",
  "js-sys",
@@ -8608,9 +8626,9 @@ dependencies = [
  "once_cell",
  "orbclient",
  "percent-encoding",
- "raw-window-handle 0.6.0",
+ "raw-window-handle 0.6.1",
  "redox_syscall 0.3.5",
- "rustix 0.38.32",
+ "rustix 0.38.34",
  "sctk-adwaita",
  "smithay-client-toolkit",
  "smol_str",
@@ -8640,9 +8658,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.6.5"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dffa400e67ed5a4dd237983829e66475f0a4a26938c4b04c21baede6262215b8"
+checksum = "14b9415ee827af173ebb3f15f9083df5a122eb93572ec28741fb153356ea2578"
 dependencies = [
  "memchr",
 ]
@@ -8716,7 +8734,7 @@ dependencies = [
  "libc",
  "libloading 0.8.3",
  "once_cell",
- "rustix 0.38.32",
+ "rustix 0.38.34",
  "x11rb-protocol",
 ]
 
@@ -8756,7 +8774,7 @@ checksum = "8da84f1a25939b27f6820d92aed108f83ff920fdf11a7b19366c27c4cda81d4f"
 dependencies = [
  "libc",
  "linux-raw-sys 0.4.13",
- "rustix 0.38.32",
+ "rustix 0.38.34",
 ]
 
 [[package]]
@@ -8850,9 +8868,9 @@ version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
- "proc-macro2 1.0.79",
- "quote 1.0.35",
- "syn 2.0.57",
+ "proc-macro2 1.0.81",
+ "quote 1.0.36",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -8870,9 +8888,9 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
- "proc-macro2 1.0.79",
- "quote 1.0.35",
- "syn 2.0.57",
+ "proc-macro2 1.0.81",
+ "quote 1.0.36",
+ "syn 2.0.60",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,8 +51,8 @@ json-gettext = "3.2.8"
 strfmt = "0.1.6"
 once_cell = "1.6.0"
 lazy_static = "1"
-serde = { version = "1.0", features=['derive'] }
-serde_json = "1.0.59"
+serde = { version = "1", features=['derive'] }
+serde_json = "1"
 reqwest = { version = "0.11", features = ["json", "blocking"] }
 uuid = "0.8.2"
 

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -66,7 +66,7 @@ regex = "1.4.3"
 fancy-regex = "0.5.0" # Regex with backtracking
 async-std = { version = "1.9.0", features = ["unstable"] }
 dirs-next = "2.0.0"
-serde = { version = "1.0.123", features = ['derive'] }
+serde = { version = "1", features = ['derive'] }
 serde_yaml = "0.8.17"
 serde_json = "1.0.62"
 serde_urlencoded = "0.7"

--- a/crates/core/src/config/mod.rs
+++ b/crates/core/src/config/mod.rs
@@ -44,6 +44,7 @@ pub struct Config {
 	#[serde(default = "default_true")]
 	pub alternating_row_colors: bool,
 
+	//TODO: These default values aren't working
 	#[serde(default = "default_true")]
 	pub is_keybindings_enabled: bool,
 

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -20,6 +20,8 @@ pub enum GrinWalletInterfaceError {
 	InvalidTxLogState,
 	#[error("Invalid Invoice Proof")]
 	InvalidInvoiceProof,
+	#[error("Invalid Recovery Phrase")]
+	InvalidRecoveryPhrase,
 	#[error("Can't read wallet config file at {file}")]
 	ConfigReadError { file: String },
 }

--- a/crates/core/src/fs/mod.rs
+++ b/crates/core/src/fs/mod.rs
@@ -16,6 +16,8 @@ pub use save::PersistentData;
 #[cfg(feature = "default")]
 pub use theme::{import_theme, load_user_themes};
 
+pub const GRINGUI_CONFIG_DIR: &str = ".grin-gui";
+
 pub static CONFIG_DIR: Lazy<Mutex<PathBuf>> = Lazy::new(|| {
 	// Returns the location of the config directory. Will create if it doesn't
 	// exist.
@@ -24,7 +26,7 @@ pub static CONFIG_DIR: Lazy<Mutex<PathBuf>> = Lazy::new(|| {
 	#[cfg(not(windows))]
 	{
 		let home = env::var("HOME").expect("user home directory not found.");
-		let config_dir = PathBuf::from(&home).join(".grin/gui");
+		let config_dir = PathBuf::from(&home).join(&format!("{}/gui", GRINGUI_CONFIG_DIR));
 
 		Mutex::new(config_dir)
 	}
@@ -36,7 +38,7 @@ pub static CONFIG_DIR: Lazy<Mutex<PathBuf>> = Lazy::new(|| {
 	#[cfg(windows)]
 	{
 		let config_dir = dirs_next::home_dir()
-			.map(|path| path.join(".grin"))
+			.map(|path| path.join(GRINGUI_CONFIG_DIR))
 			.map(|path| path.join("gui"))
 			.expect("user home directory not found.");
 

--- a/crates/core/src/fs/save.rs
+++ b/crates/core/src/fs/save.rs
@@ -25,6 +25,7 @@ pub trait PersistentData: DeserializeOwned + Serialize {
 	/// Load from `PersistentData::path()`.
 	fn load() -> Result<Self> {
 		let path = Self::path()?;
+		println!("{:?}", path);
 
 		if path.exists() {
 			let file = fs::File::open(&path)?;
@@ -39,7 +40,6 @@ pub trait PersistentData: DeserializeOwned + Serialize {
 	/// and return that object.
 	fn load_or_default<T: PersistentData + Default>() -> Result<T> {
 		let load_result = <T as PersistentData>::load();
-
 		match load_result {
 			Ok(deser) => Ok(deser),
 			_ => Ok(get_default_and_save()?),

--- a/crates/core/src/node/mod.rs
+++ b/crates/core/src/node/mod.rs
@@ -15,7 +15,7 @@ use std::time::Duration;
 
 use chrono::prelude::Utc;
 
-use crate::logger;
+use crate::{fs::GRINGUI_CONFIG_DIR, logger};
 
 pub use global::ChainTypes;
 
@@ -29,10 +29,6 @@ pub use grin_chain::types::SyncStatus;
 pub use grin_core::core::{amount_from_hr_string, amount_to_hr_string};
 pub use grin_keychain::Identifier;
 pub use grin_servers::ServerStats;
-
-/// TODO - this differs from the default directory in 5.x,
-/// need to reconcile this with existing installs somehow
-const GRIN_HOME: &str = ".grin";
 
 pub const GRIN_TOP_LEVEL_DIR: &str = "grin_node";
 
@@ -51,7 +47,7 @@ fn get_grin_node_default_path(chain_type: &global::ChainTypes) -> PathBuf {
 		Some(p) => p,
 		None => PathBuf::new(),
 	};
-	grin_path.push(GRIN_HOME);
+	grin_path.push(GRINGUI_CONFIG_DIR);
 	grin_path.push(chain_type.shortname());
 	grin_path.push(GRIN_TOP_LEVEL_DIR);
 	grin_path.push(GRIN_DEFAULT_DIR);

--- a/crates/core/src/theme/mod.rs
+++ b/crates/core/src/theme/mod.rs
@@ -23,6 +23,7 @@ pub mod scrollable;
 pub mod table_header;
 pub mod table_row;
 pub mod text;
+pub mod text_editor;
 pub mod text_input;
 
 pub use button::ButtonStyle;
@@ -35,6 +36,7 @@ pub use radio::RadioStyle;
 pub use scrollable::ScrollableStyle;
 pub use table_header::TableHeaderStyle;
 pub use table_row::TableRowStyle;
+pub use text_editor::TextEditorStyle;
 pub use text_input::TextInputStyle;
 
 pub async fn load_user_themes() -> Vec<Theme> {
@@ -56,6 +58,8 @@ pub type Column<'a, Message> = iced::widget::Column<'a, Message, Theme, Renderer
 pub type Row<'a, Message> = iced::widget::Row<'a, Message, Theme, Renderer>;
 pub type Text<'a> = iced::widget::Text<'a, Theme, Renderer>;
 pub type TextInput<'a, Message> = iced::widget::TextInput<'a, Message, Theme, Renderer>;
+pub type TextEditor<'a, Message, Theme, Renderer> =
+	iced::widget::TextEditor<'a, Message, Theme, Renderer>;
 pub type Button<'a, Message> = iced::widget::Button<'a, Message, Theme, Renderer>;
 pub type Scrollable<'a, Message> = iced::widget::Scrollable<'a, Message, Theme, Renderer>;
 pub type PickList<'a, T, L, V, Message> =

--- a/crates/core/src/theme/text_editor.rs
+++ b/crates/core/src/theme/text_editor.rs
@@ -1,0 +1,88 @@
+use super::Theme;
+use iced::widget::text_editor;
+use iced::{Background, Color};
+use iced_core::Border;
+
+#[derive(Debug, Clone, Copy, Default)]
+pub enum TextEditorStyle {
+	#[default]
+	Default,
+}
+
+impl text_editor::StyleSheet for Theme {
+	type Style = TextEditorStyle;
+
+	/// Produces the style of an active text input.
+	fn active(&self, style: &Self::Style) -> text_editor::Appearance {
+		match style {
+			TextEditorStyle::Default => text_editor::Appearance {
+				background: Background::Color(self.palette.base.foreground),
+				border: Border {
+					color: self.palette.normal.primary,
+					width: 1.0,
+					radius: 2.0.into(),
+				},
+			},
+		}
+	}
+
+	/// Produces the style of a focused text input.
+	fn focused(&self, style: &Self::Style) -> text_editor::Appearance {
+		match style {
+			TextEditorStyle::Default => text_editor::Appearance {
+				background: Background::Color(self.palette.base.foreground),
+				border: Border {
+					color: self.palette.bright.primary,
+					width: 1.0,
+					radius: 2.0.into(),
+				},
+			},
+		}
+	}
+
+	fn disabled(&self, style: &Self::Style) -> text_editor::Appearance {
+		match style {
+			TextEditorStyle::Default => text_editor::Appearance {
+				background: Background::Color(self.palette.base.foreground),
+				border: Border {
+					color: self.palette.normal.primary,
+					width: 1.0,
+					radius: 2.0.into(),
+				},
+			},
+		}
+	}
+
+	fn placeholder_color(&self, style: &Self::Style) -> Color {
+		match style {
+			TextEditorStyle::Default => self.palette.normal.surface,
+			_ => todo!("default"),
+		}
+	}
+
+	fn value_color(&self, style: &Self::Style) -> Color {
+		match style {
+			TextEditorStyle::Default => self.palette.bright.primary,
+			_ => todo!("default"),
+		}
+	}
+
+	fn selection_color(&self, style: &Self::Style) -> Color {
+		match style {
+			TextEditorStyle::Default => self.palette.bright.secondary,
+			_ => todo!("default"),
+		}
+	}
+
+	fn disabled_color(&self, style: &Self::Style) -> Color {
+		match style {
+			TextEditorStyle::Default => self.palette.normal.secondary,
+			_ => todo!("default"),
+		}
+	}
+
+	/// Produces the style of an hovered text editor.
+	fn hovered(&self, style: &Self::Style) -> text_editor::Appearance {
+		self.focused(style)
+	}
+}

--- a/crates/core/src/wallet/mod.rs
+++ b/crates/core/src/wallet/mod.rs
@@ -11,6 +11,7 @@ pub use grin_core::global;
 use grin_core::{self};
 use grin_keychain as keychain;
 use grin_util::{file, Mutex, ZeroingString};
+use keychain::mnemonic;
 
 use super::node::amount_to_hr_string;
 use std::path::PathBuf;
@@ -142,6 +143,14 @@ pub fn get_wallet_config(path: &str) -> Result<GlobalWalletConfig, GrinWalletInt
 	match res {
 		Ok(c) => Ok(c),
 		Err(e) => Err(GrinWalletInterfaceError::ConfigReadError { file: path.into() }),
+	}
+}
+
+pub fn validate_mnemonic(mnemonic: String) -> Result<(), GrinWalletInterfaceError> {
+	let result = mnemonic::to_entropy(&mnemonic);
+	match result {
+		Ok(_) => Ok(()),
+		Err(_) => Err(GrinWalletInterfaceError::InvalidRecoveryPhrase),
 	}
 }
 

--- a/crates/core/src/wallet/mod.rs
+++ b/crates/core/src/wallet/mod.rs
@@ -37,6 +37,8 @@ pub use grin_wallet_libwallet::contract::proofs::InvoiceProof;
 use crate::error::GrinWalletInterfaceError;
 use crate::logger;
 
+use crate::fs::GRINGUI_CONFIG_DIR;
+
 use std::convert::TryFrom;
 
 /// Wallet configuration file name
@@ -44,7 +46,6 @@ pub const WALLET_CONFIG_FILE_NAME: &str = "grin-wallet.toml";
 
 const WALLET_LOG_FILE_NAME: &str = "grin-wallet.log";
 
-const GRIN_HOME: &str = ".grin";
 /// Wallet data directory
 pub const GRIN_WALLET_DIR: &str = "wallet_data";
 /// Wallet top level directory
@@ -65,7 +66,7 @@ pub fn get_grin_wallet_default_path(chain_type: &global::ChainTypes) -> PathBuf 
 		Some(p) => p,
 		None => PathBuf::new(),
 	};
-	grin_path.push(GRIN_HOME);
+	grin_path.push(GRINGUI_CONFIG_DIR);
 	grin_path.push(chain_type.shortname());
 	grin_path.push(GRIN_WALLET_TOP_LEVEL_DIR);
 	grin_path.push(GRIN_WALLET_DEFAULT_DIR);
@@ -79,7 +80,7 @@ pub fn create_grin_wallet_path(chain_type: &global::ChainTypes, sub_dir: &str) -
 		Some(p) => p,
 		None => PathBuf::new(),
 	};
-	grin_path.push(GRIN_HOME);
+	grin_path.push(GRINGUI_CONFIG_DIR);
 	grin_path.push(chain_type.shortname());
 	grin_path.push(GRIN_WALLET_TOP_LEVEL_DIR);
 	grin_path.push(sub_dir);

--- a/locale/de.json
+++ b/locale/de.json
@@ -78,6 +78,7 @@
     "remote-release-channel": "Veröffentlichungskanal",
     "reset-columns": "Spalten zurücksetzen",
     "restore-from-seed": "Restore this wallet from an existing seed phrase",
+    "enter-seed-phrase": "Enter Seed Phrase",
     "retry": "Erneut versuchen",
     "scale": "Skalierung",
     "search-for-addon": "Suche nach einem Addon",

--- a/locale/de.json
+++ b/locale/de.json
@@ -224,7 +224,7 @@
     "info-awaiting-confirmation": "Awaiting Confirmation",
     "info-awaiting-finalization": "Awaiting Finalization",
     "info-locked": "Locked",
-    "wallet-default-name": "Default",
+    "wallet-default-name": "My Grin Wallet",
     "wallet-create-tx": "Start",
     "wallet-apply-tx": "Continue",
     "wallet-create-contract": "Create Contract",

--- a/locale/en.json
+++ b/locale/en.json
@@ -208,7 +208,7 @@
     "status-line-title-main": "Status Mainnet",
     "status-line-title-test": "Status Testnet",
     "wallet-list": "Wallets",
-    "wallet-default-name": "Default",
+    "wallet-default-name": "My Grin Wallet",
     "yes": "Yes",
     "no": "No",
     "cancel": "Cancel",

--- a/locale/en.json
+++ b/locale/en.json
@@ -78,6 +78,7 @@
     "remote-release-channel": "Release channel",
     "reset-columns": "Reset Columns",
     "restore-from-seed": "Restore this wallet from an existing seed phrase (TBD)",
+    "enter-seed-phrase": "Enter Seed Phrase:",
     "retry": "Retry",
     "scale": "Scale",
     "search-for-addon": "Search for an addon...",

--- a/locale/en.json
+++ b/locale/en.json
@@ -78,7 +78,7 @@
     "remote-release-channel": "Release channel",
     "reset-columns": "Reset Columns",
     "restore-from-seed": "Restore this wallet from an existing seed phrase (TBD)",
-    "enter-seed-phrase": "Enter Seed Phrase:",
+    "enter-seed-phrase": "Enter Seed Phrase",
     "retry": "Retry",
     "scale": "Scale",
     "search-for-addon": "Search for an addon...",

--- a/src/gui/element/menu.rs
+++ b/src/gui/element/menu.rs
@@ -152,7 +152,18 @@ pub fn data_container<'a>(
 
 	if let Some(e) = error {
 		// Displays an error + detail button, if any has occured.
-		let error_text = Text::new(e.to_string()).size(DEFAULT_FONT_SIZE);
+
+		let mut error_string = e.to_string();
+		let mut causes = e.chain();
+
+		let count = causes.clone().count();
+		let top_level_cause = causes.next();
+
+		if count > 1 {
+			error_string = format!("{} - {}", error_string, causes.next().unwrap());
+		}
+
+		let error_text = Text::new(error_string).size(DEFAULT_FONT_SIZE);
 
 		let error_detail_button: Button<Interaction> = Button::new(
 			Text::new(localized_string("more-error-detail"))
@@ -168,6 +179,7 @@ pub fn data_container<'a>(
 		error_column = Column::with_children(vec![
 			Space::with_height(Length::Fixed(5.0)).into(),
 			error_text.into(),
+			Space::with_height(Length::Fixed(5.0)).into(),
 			error_detail_button.map(Message::Interaction),
 		])
 		.align_items(Alignment::Center);

--- a/src/gui/element/wallet/setup/wallet_setup.rs
+++ b/src/gui/element/wallet/setup/wallet_setup.rs
@@ -6,6 +6,7 @@ use std::path::PathBuf;
 use {
 	super::super::super::{
 		BUTTON_HEIGHT, BUTTON_WIDTH, DEFAULT_FONT_SIZE, DEFAULT_HEADER_FONT_SIZE, DEFAULT_PADDING,
+		DEFAULT_SUB_HEADER_FONT_SIZE,
 	},
 	crate::gui::{GrinGui, Interaction, Message},
 	crate::localization::localized_string,
@@ -297,6 +298,24 @@ pub fn data_container<'a>(
 		DEFAULT_PADDING as u16, // bottom
 		0,                      // left
 	]));
+	let display_name = Text::new(localized_string("display-name"))
+		.size(DEFAULT_SUB_HEADER_FONT_SIZE)
+		.horizontal_alignment(alignment::Horizontal::Left);
+
+	let display_name_container =
+		Container::new(display_name).style(grin_gui_core::theme::ContainerStyle::NormalBackground);
+
+	let display_name_input = TextInput::new(
+		default_display_name,
+		&state.advanced_options_state.display_name_value,
+	)
+	.on_input(|s| {
+		Interaction::WalletSetupWalletViewInteraction(LocalViewInteraction::DisplayName(s))
+	})
+	.size(DEFAULT_FONT_SIZE)
+	.padding(6)
+	.width(Length::Fixed(200.0))
+	.style(grin_gui_core::theme::TextInputStyle::AddonsQuery);
 
 	let password_column = {
 		let password_input = TextInput::new(
@@ -365,7 +384,7 @@ pub fn data_container<'a>(
 	};
 
 	let description = Text::new(localized_string("setup-grin-wallet-enter-password"))
-		.size(DEFAULT_FONT_SIZE)
+		.size(DEFAULT_SUB_HEADER_FONT_SIZE)
 		.horizontal_alignment(alignment::Horizontal::Center);
 	let description_container =
 		Container::new(description).style(grin_gui_core::theme::ContainerStyle::NormalBackground);
@@ -437,27 +456,8 @@ pub fn data_container<'a>(
 
 	// ** start hideable advanced options
 	//let display_name_label =
-	let display_name = Text::new(localized_string("display-name"))
-		.size(DEFAULT_FONT_SIZE)
-		.horizontal_alignment(alignment::Horizontal::Left);
-
-	let display_name_container =
-		Container::new(display_name).style(grin_gui_core::theme::ContainerStyle::NormalBackground);
-
-	let display_name_input = TextInput::new(
-		default_display_name,
-		&state.advanced_options_state.display_name_value,
-	)
-	.on_input(|s| {
-		Interaction::WalletSetupWalletViewInteraction(LocalViewInteraction::DisplayName(s))
-	})
-	.size(DEFAULT_FONT_SIZE)
-	.padding(6)
-	.width(Length::Fixed(200.0))
-	.style(grin_gui_core::theme::TextInputStyle::AddonsQuery);
-
 	let tld = Text::new(localized_string("top-level-domain"))
-		.size(DEFAULT_FONT_SIZE)
+		.size(DEFAULT_SUB_HEADER_FONT_SIZE)
 		.horizontal_alignment(alignment::Horizontal::Left);
 
 	let tld_container =
@@ -509,9 +509,6 @@ pub fn data_container<'a>(
 	let is_testnet_row = Row::new().push(is_testnet_checkbox.map(Message::Interaction));
 
 	let advanced_options_column = Column::new()
-		.push(display_name_container)
-		.push(display_name_input.map(Message::Interaction))
-		.push(Space::new(Length::Fixed(0.0), Length::Fixed(5.0)))
 		.push(tld_container)
 		.spacing(DEFAULT_PADDING)
 		.push(folder_select_row)
@@ -584,6 +581,10 @@ pub fn data_container<'a>(
 		.push(cancel_container);
 
 	let mut column = Column::new()
+		.push(display_name_container)
+		.push(Space::new(Length::Fixed(0.0), Length::Fixed(unit_spacing)))
+		.push(display_name_input.map(Message::Interaction))
+		.push(Space::new(Length::Fixed(0.0), Length::Fixed(5.0)))
 		.push(Space::new(Length::Fixed(0.0), Length::Fixed(unit_spacing)))
 		.push(description_container)
 		.push(Space::new(Length::Fixed(0.0), Length::Fixed(unit_spacing)))

--- a/src/gui/update.rs
+++ b/src/gui/update.rs
@@ -10,7 +10,11 @@ use {
 	std::path::PathBuf,
 };
 
-use iced::window;
+use iced::{
+	widget::{focus_next, focus_previous},
+	window,
+};
+use iced_core::SmolStr;
 
 #[cfg(target_os = "windows")]
 use crate::tray::{TrayMessage, SHOULD_EXIT, TRAY_SENDER};
@@ -319,31 +323,31 @@ pub fn handle_message(grin_gui: &mut GrinGui, message: Message) -> Result<Comman
 				modifiers,
 			},
 		)) => {
+			/*debug!(
+				"Event::Keyboard::KeyReleased({:?}, {:?}, {:?})",
+				key, location, modifiers
+			);*/
 			// Bail out of keybindings if keybindings is diabled, or we are
 			// pressing any modifiers.
-			if !grin_gui.config.is_keybindings_enabled
-				|| modifiers != iced::keyboard::Modifiers::default()
-			{
+			/*if !grin_gui.config.is_keybindings_enabled {
 				return Ok(Command::none());
-			}
+			}*/
 
-			match key {
-				iced::keyboard::Key::Character(A) => {}
-				iced::keyboard::Key::Character(C) => {
-					grin_gui.mode = Mode::Catalog;
-				}
-				iced::keyboard::Key::Character(R) => {}
-				iced::keyboard::Key::Character(S) => {
-					grin_gui.mode = Mode::Settings;
-				}
-				iced::keyboard::Key::Character(U) => {}
-				iced::keyboard::Key::Character(W) => {}
-				iced::keyboard::Key::Character(I) => {
-					grin_gui.mode = Mode::Install;
+			match key.as_ref() {
+				iced::keyboard::Key::Character("w") => {
+					// Just testing for now
+					debug!("w pressed");
 				}
 				iced::keyboard::Key::Named(iced::keyboard::key::Named::Escape) => {
 					match grin_gui.mode {
 						_ => (),
+					}
+				}
+				iced::keyboard::Key::Named(iced::keyboard::key::Named::Tab) => {
+					if modifiers.shift() {
+						return Ok(focus_previous::<Message>());
+					} else {
+						return Ok(focus_next::<Message>());
 					}
 				}
 				_ => (),


### PR DESCRIPTION
Part of an effort to go through the app screen-by-screen, testing, fixing, and adding missing functionality.

* Move grin-gui related files to `$HOME\.grin-gui` instead of `$HOME\grin` as requested by #76
* Wallet name no longer 'advanced', change to `My Grin Wallet` as default name
* Some font changes on Advanced Screen
* Implement tab/shift-tab to cycle through text inputs, note this functionality is incomplete in iced-rs, and tabbing / keyboard focus doesn't work on anything other than text inputs
* Default app styling for iced new `TextEditor` widget
* Add `restore from keyphrase` TextEditor to create wallet screen
* Changes to default error message display to show more information without having to click on 'detail'
* Hook up recovery phrase to wallet creation, and validate if box is selected
* Update from 5.3.0 merged contracts branch